### PR TITLE
Add e1000 driver for host devices for bonding

### DIFF
--- a/templates/Vagrantfile.j2
+++ b/templates/Vagrantfile.j2
@@ -301,6 +301,7 @@ Vagrant.configure("2") do |config|
     device.vm.synced_folder '.', '/vagrant', :disabled => true
     device.vm.provider :libvirt do |v|{% endif %}
       v.memory = {{ device.memory }}
+      {% if 'vx' not in device.os %} v.nic_model_type = 'e1000' {% endif %}
     end{% if synced_folder == False %}
     device.vm.synced_folder ".", "/vagrant", disabled: true{% endif %}{% if device.ubuntu == "True" %}
       # UBUNTU DEVICES ONLY: Shorten Boot Process - remove \"Wait for Network


### PR DESCRIPTION
Change the default virtio driver to e1000 for all interfaces on boxes not containing the name "vx", ie host machines.  This is needed to allow creation of compatible bonds on hosts with Cumulus VX devices using the default virtio driver.  The issue was tested with the virtio driver loaded on a Ubuntu machine where it is not setting correct L1 parameters for a bond interface.  NOTE: This fix will change the driver to e1000 for all interfaces on the host.  Another way to fix is to change only the network facing ports but waiting on fix for: https://github.com/vagrant-libvirt/vagrant-libvirt/issues/634