### PR TITLE
require Vagrant 2.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 ![Reference Topology](./documentation/cldemo_topology.png "Reference Topology")
 
 
-Welcome to the Cumulus Linux Demo Framework, which provides virtual demos of features and 
-configurations with Cumulus Linux. Follow the [Prerequisites and Getting Started](#prerequisites-and-getting-started) 
+Welcome to the Cumulus Linux Demo Framework, which provides virtual demos of features and
+configurations with Cumulus Linux. Follow the [Prerequisites and Getting Started](#prerequisites-and-getting-started)
 instructions below to get started.
 
 ## Table of Conents
@@ -38,10 +38,10 @@ instructions below to get started.
 
 ## Available Demos
 
-Once you've followed the above prerequisite/getting-started instructions for your system, 
-you are able to run any of the demos below. 
+Once you've followed the above prerequisite/getting-started instructions for your system,
+you are able to run any of the demos below.
 
-Demos are built upon the Reference Topology as a starting point and then layer specific 
+Demos are built upon the Reference Topology as a starting point and then layer specific
 device configuration on top.
 
 * **[Cldemo-config-routing](https://github.com/CumulusNetworks/cldemo-config-routing)** -- This Github repository contains the configuration files necessary for setting up Layer 3 routing on a CLOS topology using Cumulus Linux and Quagga.
@@ -62,29 +62,29 @@ device configuration on top.
 * **[Cldemo-dynamic-ansible-inventory](https://github.com/CumulusNetworks/cldemo-dynamic-ansible-inventory)** -- A demonstration of using Ansible with external data sources, specifically Redis or MySQL databases.
 * **[Cldemo-docker-macvlan](https://github.com/CumulusNetworks/cldemo-docker-macvlan)** -- A demonstration of advertising docker containers using the macvlan networking option.
 * **[NetQDemo-1.0](https://github.com/CumulusNetworks/netqdemo-1.0)** -- Demos using NetQ. **NOTE: The NetQ VM is available for Cumulus Customers**
-* **[cldemo-evpn-symmetric](https://github.com/CumulusNetworks/cldemo-evpn-symmetric)** -- Provides a setup to show a VXLAN Routing with EVPN environment using the symmetric IRB model. 
+* **[cldemo-evpn-symmetric](https://github.com/CumulusNetworks/cldemo-evpn-symmetric)** -- Provides a setup to show a VXLAN Routing with EVPN environment using the symmetric IRB model.
 
 
 ## Frequently Asked Questions
 
 ### What is CLDEMO-VAGRANT?
-CLDEMO-VAGRANT is the name of this repository which provides a consistent 
-physical topology of VMs which are cabled together in a configuration 
-we refer to as the [Reference Topology](#what-is-the-reference-topology). This topology provides a 
-consistent simulation topology upon which lots of different configurations 
-can be overlaid. The [individual demos](#available-demos) provide interface and routing protocol 
+CLDEMO-VAGRANT is the name of this repository which provides a consistent
+physical topology of VMs which are cabled together in a configuration
+we refer to as the [Reference Topology](#what-is-the-reference-topology). This topology provides a
+consistent simulation topology upon which lots of different configurations
+can be overlaid. The [individual demos](#available-demos) provide interface and routing protocol
 configurations which are applied to this simulation topology.
 
 ### What is the Reference Topology?
-The Cumulus Linux Demo Framework is built upon a [Vagrantfile](#what-is-a-vagrantfile) which builds 
-the Reference Topology. Using this topology, it is possible to demonstrate 
-any feature in Cumulus Linux. It may not be necessary to use all links or 
+The Cumulus Linux Demo Framework is built upon a [Vagrantfile](#what-is-a-vagrantfile) which builds
+the Reference Topology. Using this topology, it is possible to demonstrate
+any feature in Cumulus Linux. It may not be necessary to use all links or
 all devices but they're present if needed by a particular demo.
 
 This framework of demos is built on a two-tier spine-leaf [Clos network](https://en.wikipedia.org/wiki/Clos_network) with a
-dedicated out-of-band management network. The Reference Topology built in 
-this repository is used for all Cumulus Networks documentation, demos, 
-and course materials, so many demos will require you to build a topology 
+dedicated out-of-band management network. The Reference Topology built in
+this repository is used for all Cumulus Networks documentation, demos,
+and course materials, so many demos will require you to build a topology
 using the code available in this repository.
 
 ### What is Cumulus VX?
@@ -100,11 +100,11 @@ configurations, develop automation code, and simulate failure scenarios.
 Vagrant uses [Vagrantfiles](#what-is-a-vagrantfile) to represent the topology.
 
 ### What is a Vagrantfile?
-Vagrant topologies are described in a text file called a "Vagrantfile," 
+Vagrant topologies are described in a text file called a "Vagrantfile,"
 which is also the filename. A Vagrantfile is a Ruby program that
 tells Vagrant which devices to create and how to configure their networks.
 `vagrant up` will execute the Vagrantfile and create the reference topology
-using Virtualbox. 
+using Virtualbox.
 
 ### What is Libvirt/KVM?
 Libvirt/KVM is a high-performance hypervisor that is used on Linux systems **ONLY**.
@@ -118,9 +118,9 @@ Libvirt/KVM offers several notable advantages over Virtualbox:
 As a result this tends to be the most common hypervisor for larger simulations.
 
 ### Which Software Versions Should I Use?
-Software versions are always changing. At the time of this writing the following 
-versions are known to work well: 
-* Vagrant v1.9.5
+Software versions are always changing. At the time of this writing the following
+versions are known to work well:
+* Vagrant v2.0.2
 * Virtualbox v5.1.22
 * Libvirt v1.3.1
 
@@ -153,10 +153,10 @@ Out-of-Band Network check the [IPAM diagram](./documentation/ipam.md)
 
 ### Tips on Managing the VMs in the Topology
 The topology built using this Vagrantfile does not support `vagrant halt` or
-`vagrant resume` for in-band devices. To resume working with the demos at a later point in time, use 
+`vagrant resume` for in-band devices. To resume working with the demos at a later point in time, use
 the hypervisor's halt and resume functionality.
 
-In Virtualbox this can be done inside of the GUI by powering off (and later powering-on) the devices 
+In Virtualbox this can be done inside of the GUI by powering off (and later powering-on) the devices
 involved in the simulation or by running the following CLI commands:
 
     * VBoxManage controlvm leaf01 poweroff
@@ -180,15 +180,15 @@ When using the libvirt/kvm hypervisor the following commands can be used:
 
 ### Can I Preserve My Configuration
 In order to keep your configuration across Vagrant sessions, you should either save your configuration
-in a repository using an automation tool such as Ansible, Puppet, or Chef (preferred) or alternatively 
-copy the configuration files off of the VMs before running the "vagrant destroy" command to remove and 
+in a repository using an automation tool such as Ansible, Puppet, or Chef (preferred) or alternatively
+copy the configuration files off of the VMs before running the "vagrant destroy" command to remove and
 destroy the VMs involved in the simulation.
 
 One helpful command for saving configuration from Cumulus devices is:
 
     net show configuration files
 
-or 
+or
 
     net show configuration command
 
@@ -200,7 +200,7 @@ slightly from hypervisor to hypervisor.
 
 #### Virtualbox
 In the Vagrantfile built for Virtualbox there is a line which sets `simid= [some integer]` in order to
-create unique simulations a text editor can be used to modify the simid value to something unique which 
+create unique simulations a text editor can be used to modify the simid value to something unique which
 does not match other running simulations on the simulation node.
 
 #### Libvirt
@@ -220,8 +220,8 @@ from 8000-10000 --> 30000-32000.
 
 ### How Can I Customize the Topology?
 This Vagrant topology is built using [Topology Converter](https://github.com/cumulusnetworks/topology_converter).
-To create your own arbitrary topology, we recommend using Topology Converter. This will create a new 
-Vagrantfile which is specific to your environment.For more details on how to make customized 
+To create your own arbitrary topology, we recommend using Topology Converter. This will create a new
+Vagrantfile which is specific to your environment.For more details on how to make customized
 topologies, read Topology Converter's [documentation](https://github.com/CumulusNetworks/topology_converter/tree/master/documentation).
 
 #### **Advanced Users ONLY: ** Editing the existing topology
@@ -254,11 +254,11 @@ conflict with Virtualbox's ability to create 64-bit VMs.**
 
 ---
 
->©2017 Cumulus Networks. CUMULUS, the Cumulus Logo, CUMULUS NETWORKS, and the Rocket Turtle Logo 
-(the “Marks”) are trademarks and service marks of Cumulus Networks, Inc. in the U.S. and other 
-countries. You are not permitted to use the Marks without the prior written consent of Cumulus 
-Networks. The registered trademark Linux® is used pursuant to a sublicense from LMI, the exclusive 
-licensee of Linus Torvalds, owner of the mark on a world-wide basis. All other marks are used under 
+>©2017 Cumulus Networks. CUMULUS, the Cumulus Logo, CUMULUS NETWORKS, and the Rocket Turtle Logo
+(the “Marks”) are trademarks and service marks of Cumulus Networks, Inc. in the U.S. and other
+countries. You are not permitted to use the Marks without the prior written consent of Cumulus
+Networks. The registered trademark Linux® is used pursuant to a sublicense from LMI, the exclusive
+licensee of Linus Torvalds, owner of the mark on a world-wide basis. All other marks are used under
 fair use or license from their respective owners.
 
 For further details please see: [cumulusnetworks.com](http://www.cumulusnetworks.com)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 ![Reference Topology](./documentation/cldemo_topology.png "Reference Topology")
 
 
-Welcome to the Cumulus Linux Demo Framework, which provides virtual demos of features and
-configurations with Cumulus Linux. Follow the [Prerequisites and Getting Started](#prerequisites-and-getting-started)
+Welcome to the Cumulus Linux Demo Framework, which provides virtual demos of features and 
+configurations with Cumulus Linux. Follow the [Prerequisites and Getting Started](#prerequisites-and-getting-started) 
 instructions below to get started.
 
 ## Table of Conents
@@ -38,10 +38,10 @@ instructions below to get started.
 
 ## Available Demos
 
-Once you've followed the above prerequisite/getting-started instructions for your system,
-you are able to run any of the demos below.
+Once you've followed the above prerequisite/getting-started instructions for your system, 
+you are able to run any of the demos below. 
 
-Demos are built upon the Reference Topology as a starting point and then layer specific
+Demos are built upon the Reference Topology as a starting point and then layer specific 
 device configuration on top.
 
 * **[Cldemo-config-routing](https://github.com/CumulusNetworks/cldemo-config-routing)** -- This Github repository contains the configuration files necessary for setting up Layer 3 routing on a CLOS topology using Cumulus Linux and Quagga.
@@ -62,29 +62,29 @@ device configuration on top.
 * **[Cldemo-dynamic-ansible-inventory](https://github.com/CumulusNetworks/cldemo-dynamic-ansible-inventory)** -- A demonstration of using Ansible with external data sources, specifically Redis or MySQL databases.
 * **[Cldemo-docker-macvlan](https://github.com/CumulusNetworks/cldemo-docker-macvlan)** -- A demonstration of advertising docker containers using the macvlan networking option.
 * **[NetQDemo-1.0](https://github.com/CumulusNetworks/netqdemo-1.0)** -- Demos using NetQ. **NOTE: The NetQ VM is available for Cumulus Customers**
-* **[cldemo-evpn-symmetric](https://github.com/CumulusNetworks/cldemo-evpn-symmetric)** -- Provides a setup to show a VXLAN Routing with EVPN environment using the symmetric IRB model.
+* **[cldemo-evpn-symmetric](https://github.com/CumulusNetworks/cldemo-evpn-symmetric)** -- Provides a setup to show a VXLAN Routing with EVPN environment using the symmetric IRB model. 
 
 
 ## Frequently Asked Questions
 
 ### What is CLDEMO-VAGRANT?
-CLDEMO-VAGRANT is the name of this repository which provides a consistent
-physical topology of VMs which are cabled together in a configuration
-we refer to as the [Reference Topology](#what-is-the-reference-topology). This topology provides a
-consistent simulation topology upon which lots of different configurations
-can be overlaid. The [individual demos](#available-demos) provide interface and routing protocol
+CLDEMO-VAGRANT is the name of this repository which provides a consistent 
+physical topology of VMs which are cabled together in a configuration 
+we refer to as the [Reference Topology](#what-is-the-reference-topology). This topology provides a 
+consistent simulation topology upon which lots of different configurations 
+can be overlaid. The [individual demos](#available-demos) provide interface and routing protocol 
 configurations which are applied to this simulation topology.
 
 ### What is the Reference Topology?
-The Cumulus Linux Demo Framework is built upon a [Vagrantfile](#what-is-a-vagrantfile) which builds
-the Reference Topology. Using this topology, it is possible to demonstrate
-any feature in Cumulus Linux. It may not be necessary to use all links or
+The Cumulus Linux Demo Framework is built upon a [Vagrantfile](#what-is-a-vagrantfile) which builds 
+the Reference Topology. Using this topology, it is possible to demonstrate 
+any feature in Cumulus Linux. It may not be necessary to use all links or 
 all devices but they're present if needed by a particular demo.
 
 This framework of demos is built on a two-tier spine-leaf [Clos network](https://en.wikipedia.org/wiki/Clos_network) with a
-dedicated out-of-band management network. The Reference Topology built in
-this repository is used for all Cumulus Networks documentation, demos,
-and course materials, so many demos will require you to build a topology
+dedicated out-of-band management network. The Reference Topology built in 
+this repository is used for all Cumulus Networks documentation, demos, 
+and course materials, so many demos will require you to build a topology 
 using the code available in this repository.
 
 ### What is Cumulus VX?
@@ -100,11 +100,11 @@ configurations, develop automation code, and simulate failure scenarios.
 Vagrant uses [Vagrantfiles](#what-is-a-vagrantfile) to represent the topology.
 
 ### What is a Vagrantfile?
-Vagrant topologies are described in a text file called a "Vagrantfile,"
+Vagrant topologies are described in a text file called a "Vagrantfile," 
 which is also the filename. A Vagrantfile is a Ruby program that
 tells Vagrant which devices to create and how to configure their networks.
 `vagrant up` will execute the Vagrantfile and create the reference topology
-using Virtualbox.
+using Virtualbox. 
 
 ### What is Libvirt/KVM?
 Libvirt/KVM is a high-performance hypervisor that is used on Linux systems **ONLY**.
@@ -118,8 +118,8 @@ Libvirt/KVM offers several notable advantages over Virtualbox:
 As a result this tends to be the most common hypervisor for larger simulations.
 
 ### Which Software Versions Should I Use?
-Software versions are always changing. At the time of this writing the following
-versions are known to work well:
+Software versions are always changing. At the time of this writing the following 
+versions are known to work well: 
 * Vagrant v2.0.2
 * Virtualbox v5.1.22
 * Libvirt v1.3.1
@@ -153,10 +153,10 @@ Out-of-Band Network check the [IPAM diagram](./documentation/ipam.md)
 
 ### Tips on Managing the VMs in the Topology
 The topology built using this Vagrantfile does not support `vagrant halt` or
-`vagrant resume` for in-band devices. To resume working with the demos at a later point in time, use
+`vagrant resume` for in-band devices. To resume working with the demos at a later point in time, use 
 the hypervisor's halt and resume functionality.
 
-In Virtualbox this can be done inside of the GUI by powering off (and later powering-on) the devices
+In Virtualbox this can be done inside of the GUI by powering off (and later powering-on) the devices 
 involved in the simulation or by running the following CLI commands:
 
     * VBoxManage controlvm leaf01 poweroff
@@ -180,15 +180,15 @@ When using the libvirt/kvm hypervisor the following commands can be used:
 
 ### Can I Preserve My Configuration
 In order to keep your configuration across Vagrant sessions, you should either save your configuration
-in a repository using an automation tool such as Ansible, Puppet, or Chef (preferred) or alternatively
-copy the configuration files off of the VMs before running the "vagrant destroy" command to remove and
+in a repository using an automation tool such as Ansible, Puppet, or Chef (preferred) or alternatively 
+copy the configuration files off of the VMs before running the "vagrant destroy" command to remove and 
 destroy the VMs involved in the simulation.
 
 One helpful command for saving configuration from Cumulus devices is:
 
     net show configuration files
 
-or
+or 
 
     net show configuration command
 
@@ -200,7 +200,7 @@ slightly from hypervisor to hypervisor.
 
 #### Virtualbox
 In the Vagrantfile built for Virtualbox there is a line which sets `simid= [some integer]` in order to
-create unique simulations a text editor can be used to modify the simid value to something unique which
+create unique simulations a text editor can be used to modify the simid value to something unique which 
 does not match other running simulations on the simulation node.
 
 #### Libvirt
@@ -220,8 +220,8 @@ from 8000-10000 --> 30000-32000.
 
 ### How Can I Customize the Topology?
 This Vagrant topology is built using [Topology Converter](https://github.com/cumulusnetworks/topology_converter).
-To create your own arbitrary topology, we recommend using Topology Converter. This will create a new
-Vagrantfile which is specific to your environment.For more details on how to make customized
+To create your own arbitrary topology, we recommend using Topology Converter. This will create a new 
+Vagrantfile which is specific to your environment.For more details on how to make customized 
 topologies, read Topology Converter's [documentation](https://github.com/CumulusNetworks/topology_converter/tree/master/documentation).
 
 #### **Advanced Users ONLY: ** Editing the existing topology
@@ -254,11 +254,11 @@ conflict with Virtualbox's ability to create 64-bit VMs.**
 
 ---
 
->©2017 Cumulus Networks. CUMULUS, the Cumulus Logo, CUMULUS NETWORKS, and the Rocket Turtle Logo
-(the “Marks”) are trademarks and service marks of Cumulus Networks, Inc. in the U.S. and other
-countries. You are not permitted to use the Marks without the prior written consent of Cumulus
-Networks. The registered trademark Linux® is used pursuant to a sublicense from LMI, the exclusive
-licensee of Linus Torvalds, owner of the mark on a world-wide basis. All other marks are used under
+>©2017 Cumulus Networks. CUMULUS, the Cumulus Logo, CUMULUS NETWORKS, and the Rocket Turtle Logo 
+(the “Marks”) are trademarks and service marks of Cumulus Networks, Inc. in the U.S. and other 
+countries. You are not permitted to use the Marks without the prior written consent of Cumulus 
+Networks. The registered trademark Linux® is used pursuant to a sublicense from LMI, the exclusive 
+licensee of Linus Torvalds, owner of the mark on a world-wide basis. All other marks are used under 
 fair use or license from their respective owners.
 
 For further details please see: [cumulusnetworks.com](http://www.cumulusnetworks.com)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@
 
 
 
-Vagrant.require_version ">= 1.8.6"
+Vagrant.require_version ">= 2.0.2"
 
 $script = <<-SCRIPT
 if grep -q -i 'cumulus' /etc/lsb-release &> /dev/null; then
@@ -50,7 +50,7 @@ if grep -q -i 'cumulus' /etc/lsb-release &> /dev/null; then
             echo "  INFO: Detected Cumulus Linux v$DISTRIB_RELEASE Release"
             if [[ $DISTRIB_RELEASE =~ ^3.[1-9].* ]]; then
                 echo "### Fixing ONIE DHCP to avoid Vagrant Interface ###"
-                echo "     Note: Installing from ONIE will undo these changes." 
+                echo "     Note: Installing from ONIE will undo these changes."
                 mkdir /tmp/foo
                 mount LABEL=ONIE-BOOT /tmp/foo
                 sed -i 's/eth0/eth1/g' /tmp/foo/grub/grub.cfg
@@ -86,9 +86,9 @@ Vagrant.configure("2") do |config|
 
   ##### DEFINE VM for oob-mgmt-server #####
   config.vm.define "oob-mgmt-server" do |device|
-    
-    device.vm.hostname = "oob-mgmt-server" 
-    
+
+    device.vm.hostname = "oob-mgmt-server"
+
     device.vm.box = "CumulusCommunity/vx_oob_server"
     device.vm.box_version = "1.0.4"
     device.vm.provider "virtualbox" do |v|
@@ -104,7 +104,7 @@ Vagrant.configure("2") do |config|
     # NETWORK INTERFACES
       # link for eth1 --> oob-mgmt-switch:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net54", auto_config: false , :mac => "443839000057"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -114,7 +114,7 @@ Vagrant.configure("2") do |config|
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_oob_server.sh"
@@ -132,7 +132,7 @@ device.vm.provision :shell , :inline => <<-udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:57 --> eth1"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:57", NAME="eth1", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = eth0"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="eth0", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -148,9 +148,9 @@ end
 
   ##### DEFINE VM for oob-mgmt-switch #####
   config.vm.define "oob-mgmt-switch" do |device|
-    
-    device.vm.hostname = "oob-mgmt-switch" 
-    
+
+    device.vm.hostname = "oob-mgmt-switch"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -166,49 +166,49 @@ end
     # NETWORK INTERFACES
       # link for swp1 --> oob-mgmt-server:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net54", auto_config: false , :mac => "a00000000061"
-      
+
       # link for swp2 --> server01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net42", auto_config: false , :mac => "443839000043"
-      
+
       # link for swp3 --> server02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net47", auto_config: false , :mac => "44383900004c"
-      
+
       # link for swp4 --> server03:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net3", auto_config: false , :mac => "443839000004"
-      
+
       # link for swp5 --> server04:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net49", auto_config: false , :mac => "44383900004e"
-      
+
       # link for swp6 --> leaf01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net20", auto_config: false , :mac => "443839000020"
-      
+
       # link for swp7 --> leaf02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net38", auto_config: false , :mac => "44383900003d"
-      
+
       # link for swp8 --> leaf03:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net28", auto_config: false , :mac => "44383900002d"
-      
+
       # link for swp9 --> leaf04:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net34", auto_config: false , :mac => "443839000037"
-      
+
       # link for swp10 --> spine01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net31", auto_config: false , :mac => "443839000032"
-      
+
       # link for swp11 --> spine02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net59", auto_config: false , :mac => "44383900005f"
-      
+
       # link for swp12 --> exit01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net9", auto_config: false , :mac => "44383900000f"
-      
+
       # link for swp13 --> exit02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net48", auto_config: false , :mac => "44383900004d"
-      
+
       # link for swp14 --> edge01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net40", auto_config: false , :mac => "443839000040"
-      
+
       # link for swp15 --> internet:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net35", auto_config: false , :mac => "443839000038"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -232,7 +232,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_oob_switch.sh"
@@ -306,7 +306,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:38 --> swp15"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:38", NAME="swp15", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = eth0"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="eth0", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -322,9 +322,9 @@ end
 
   ##### DEFINE VM for exit02 #####
   config.vm.define "exit02" do |device|
-    
-    device.vm.hostname = "exit02" 
-    
+
+    device.vm.hostname = "exit02"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -340,37 +340,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp13
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net48", auto_config: false , :mac => "a00000000042"
-      
+
       # link for swp1 --> edge01:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net7", auto_config: false , :mac => "44383900000c"
-      
+
       # link for swp44 --> internet:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net39", auto_config: false , :mac => "44383900003f"
-      
+
       # link for swp45 --> exit02:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net30", auto_config: false , :mac => "443839000030"
-      
+
       # link for swp46 --> exit02:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net30", auto_config: false , :mac => "443839000031"
-      
+
       # link for swp47 --> exit02:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net33", auto_config: false , :mac => "443839000035"
-      
+
       # link for swp48 --> exit02:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net33", auto_config: false , :mac => "443839000036"
-      
+
       # link for swp49 --> exit01:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net24", auto_config: false , :mac => "443839000027"
-      
+
       # link for swp50 --> exit01:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net14", auto_config: false , :mac => "443839000017"
-      
+
       # link for swp51 --> spine01:swp29
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net21", auto_config: false , :mac => "443839000021"
-      
+
       # link for swp52 --> spine02:swp29
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net53", auto_config: false , :mac => "443839000055"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -390,7 +390,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -448,7 +448,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:55 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:55", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -464,9 +464,9 @@ end
 
   ##### DEFINE VM for exit01 #####
   config.vm.define "exit01" do |device|
-    
-    device.vm.hostname = "exit01" 
-    
+
+    device.vm.hostname = "exit01"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -482,37 +482,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp12
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net9", auto_config: false , :mac => "a00000000041"
-      
+
       # link for swp1 --> edge01:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net46", auto_config: false , :mac => "44383900004b"
-      
+
       # link for swp44 --> internet:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net5", auto_config: false , :mac => "443839000008"
-      
+
       # link for swp45 --> exit01:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net43", auto_config: false , :mac => "443839000044"
-      
+
       # link for swp46 --> exit01:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net43", auto_config: false , :mac => "443839000045"
-      
+
       # link for swp47 --> exit01:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net11", auto_config: false , :mac => "443839000012"
-      
+
       # link for swp48 --> exit01:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net11", auto_config: false , :mac => "443839000013"
-      
+
       # link for swp49 --> exit02:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net24", auto_config: false , :mac => "443839000026"
-      
+
       # link for swp50 --> exit02:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net14", auto_config: false , :mac => "443839000016"
-      
+
       # link for swp51 --> spine01:swp30
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net6", auto_config: false , :mac => "443839000009"
-      
+
       # link for swp52 --> spine02:swp30
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net56", auto_config: false , :mac => "44383900005a"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -532,7 +532,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -590,7 +590,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:5a --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:5a", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -606,9 +606,9 @@ end
 
   ##### DEFINE VM for spine02 #####
   config.vm.define "spine02" do |device|
-    
-    device.vm.hostname = "spine02" 
-    
+
+    device.vm.hostname = "spine02"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -624,31 +624,31 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp11
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net59", auto_config: false , :mac => "a00000000022"
-      
+
       # link for swp1 --> leaf01:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net23", auto_config: false , :mac => "443839000025"
-      
+
       # link for swp2 --> leaf02:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net58", auto_config: false , :mac => "44383900005e"
-      
+
       # link for swp3 --> leaf03:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net17", auto_config: false , :mac => "44383900001c"
-      
+
       # link for swp4 --> leaf04:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net44", auto_config: false , :mac => "443839000047"
-      
+
       # link for swp29 --> exit02:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net53", auto_config: false , :mac => "443839000056"
-      
+
       # link for swp30 --> exit01:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net56", auto_config: false , :mac => "44383900005b"
-      
+
       # link for swp31 --> spine01:swp31
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net45", auto_config: false , :mac => "443839000049"
-      
+
       # link for swp32 --> spine01:swp32
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net36", auto_config: false , :mac => "44383900003a"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -666,7 +666,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -716,7 +716,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:3a --> swp32"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:3a", NAME="swp32", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -732,9 +732,9 @@ end
 
   ##### DEFINE VM for spine01 #####
   config.vm.define "spine01" do |device|
-    
-    device.vm.hostname = "spine01" 
-    
+
+    device.vm.hostname = "spine01"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -750,31 +750,31 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp10
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net31", auto_config: false , :mac => "a00000000021"
-      
+
       # link for swp1 --> leaf01:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net52", auto_config: false , :mac => "443839000054"
-      
+
       # link for swp2 --> leaf02:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net25", auto_config: false , :mac => "443839000029"
-      
+
       # link for swp3 --> leaf03:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net50", auto_config: false , :mac => "443839000050"
-      
+
       # link for swp4 --> leaf04:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net37", auto_config: false , :mac => "44383900003c"
-      
+
       # link for swp29 --> exit02:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net21", auto_config: false , :mac => "443839000022"
-      
+
       # link for swp30 --> exit01:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net6", auto_config: false , :mac => "44383900000a"
-      
+
       # link for swp31 --> spine02:swp31
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net45", auto_config: false , :mac => "443839000048"
-      
+
       # link for swp32 --> spine02:swp32
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net36", auto_config: false , :mac => "443839000039"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -792,7 +792,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -842,7 +842,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:39 --> swp32"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:39", NAME="swp32", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -858,9 +858,9 @@ end
 
   ##### DEFINE VM for leaf04 #####
   config.vm.define "leaf04" do |device|
-    
-    device.vm.hostname = "leaf04" 
-    
+
+    device.vm.hostname = "leaf04"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -876,37 +876,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp9
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net34", auto_config: false , :mac => "a00000000014"
-      
+
       # link for swp1 --> server03:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net57", auto_config: false , :mac => "44383900005c"
-      
+
       # link for swp2 --> server04:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net27", auto_config: false , :mac => "44383900002c"
-      
+
       # link for swp45 --> leaf04:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net16", auto_config: false , :mac => "443839000019"
-      
+
       # link for swp46 --> leaf04:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net16", auto_config: false , :mac => "44383900001a"
-      
+
       # link for swp47 --> leaf04:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net32", auto_config: false , :mac => "443839000033"
-      
+
       # link for swp48 --> leaf04:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net32", auto_config: false , :mac => "443839000034"
-      
+
       # link for swp49 --> leaf03:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net29", auto_config: false , :mac => "44383900002f"
-      
+
       # link for swp50 --> leaf03:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net4", auto_config: false , :mac => "443839000006"
-      
+
       # link for swp51 --> spine01:swp4
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net37", auto_config: false , :mac => "44383900003b"
-      
+
       # link for swp52 --> spine02:swp4
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net44", auto_config: false , :mac => "443839000046"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -926,7 +926,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -984,7 +984,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:46 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:46", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1000,9 +1000,9 @@ end
 
   ##### DEFINE VM for leaf02 #####
   config.vm.define "leaf02" do |device|
-    
-    device.vm.hostname = "leaf02" 
-    
+
+    device.vm.hostname = "leaf02"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1018,37 +1018,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp7
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net38", auto_config: false , :mac => "a00000000012"
-      
+
       # link for swp1 --> server01:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net13", auto_config: false , :mac => "443839000015"
-      
+
       # link for swp2 --> server02:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net15", auto_config: false , :mac => "443839000018"
-      
+
       # link for swp45 --> leaf02:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net8", auto_config: false , :mac => "44383900000d"
-      
+
       # link for swp46 --> leaf02:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net8", auto_config: false , :mac => "44383900000e"
-      
+
       # link for swp47 --> leaf02:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net55", auto_config: false , :mac => "443839000058"
-      
+
       # link for swp48 --> leaf02:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net55", auto_config: false , :mac => "443839000059"
-      
+
       # link for swp49 --> leaf01:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net10", auto_config: false , :mac => "443839000011"
-      
+
       # link for swp50 --> leaf01:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net1", auto_config: false , :mac => "443839000002"
-      
+
       # link for swp51 --> spine01:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net25", auto_config: false , :mac => "443839000028"
-      
+
       # link for swp52 --> spine02:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net58", auto_config: false , :mac => "44383900005d"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1068,7 +1068,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1126,7 +1126,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:5d --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:5d", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1142,9 +1142,9 @@ end
 
   ##### DEFINE VM for leaf03 #####
   config.vm.define "leaf03" do |device|
-    
-    device.vm.hostname = "leaf03" 
-    
+
+    device.vm.hostname = "leaf03"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1160,37 +1160,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp8
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net28", auto_config: false , :mac => "a00000000013"
-      
+
       # link for swp1 --> server03:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net22", auto_config: false , :mac => "443839000023"
-      
+
       # link for swp2 --> server04:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net19", auto_config: false , :mac => "44383900001f"
-      
+
       # link for swp45 --> leaf03:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net26", auto_config: false , :mac => "44383900002a"
-      
+
       # link for swp46 --> leaf03:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net26", auto_config: false , :mac => "44383900002b"
-      
+
       # link for swp47 --> leaf03:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net51", auto_config: false , :mac => "443839000051"
-      
+
       # link for swp48 --> leaf03:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net51", auto_config: false , :mac => "443839000052"
-      
+
       # link for swp49 --> leaf04:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net29", auto_config: false , :mac => "44383900002e"
-      
+
       # link for swp50 --> leaf04:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net4", auto_config: false , :mac => "443839000005"
-      
+
       # link for swp51 --> spine01:swp3
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net50", auto_config: false , :mac => "44383900004f"
-      
+
       # link for swp52 --> spine02:swp3
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net17", auto_config: false , :mac => "44383900001b"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1210,7 +1210,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1268,7 +1268,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:1b --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:1b", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1284,9 +1284,9 @@ end
 
   ##### DEFINE VM for leaf01 #####
   config.vm.define "leaf01" do |device|
-    
-    device.vm.hostname = "leaf01" 
-    
+
+    device.vm.hostname = "leaf01"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1302,37 +1302,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp6
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net20", auto_config: false , :mac => "a00000000011"
-      
+
       # link for swp1 --> server01:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net2", auto_config: false , :mac => "443839000003"
-      
+
       # link for swp2 --> server02:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net12", auto_config: false , :mac => "443839000014"
-      
+
       # link for swp45 --> leaf01:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net18", auto_config: false , :mac => "44383900001d"
-      
+
       # link for swp46 --> leaf01:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net18", auto_config: false , :mac => "44383900001e"
-      
+
       # link for swp47 --> leaf01:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net41", auto_config: false , :mac => "443839000041"
-      
+
       # link for swp48 --> leaf01:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net41", auto_config: false , :mac => "443839000042"
-      
+
       # link for swp49 --> leaf02:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net10", auto_config: false , :mac => "443839000010"
-      
+
       # link for swp50 --> leaf02:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net1", auto_config: false , :mac => "443839000001"
-      
+
       # link for swp51 --> spine01:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net52", auto_config: false , :mac => "443839000053"
-      
+
       # link for swp52 --> spine02:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net23", auto_config: false , :mac => "443839000024"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1352,7 +1352,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1410,7 +1410,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:24 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:24", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1426,9 +1426,9 @@ end
 
   ##### DEFINE VM for edge01 #####
   config.vm.define "edge01" do |device|
-    
-    device.vm.hostname = "edge01" 
-    
+
+    device.vm.hostname = "edge01"
+
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_edge01"
@@ -1443,13 +1443,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp14
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net40", auto_config: false , :mac => "a00000000051"
-      
+
       # link for eth1 --> exit01:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net46", auto_config: false , :mac => "44383900004a"
-      
+
       # link for eth2 --> exit02:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net7", auto_config: false , :mac => "44383900000b"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1464,7 +1464,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1490,7 +1490,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:0b --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:0b", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1506,9 +1506,9 @@ end
 
   ##### DEFINE VM for server01 #####
   config.vm.define "server01" do |device|
-    
-    device.vm.hostname = "server01" 
-    
+
+    device.vm.hostname = "server01"
+
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server01"
@@ -1523,13 +1523,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net42", auto_config: false , :mac => "a00000000031"
-      
+
       # link for eth1 --> leaf01:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net2", auto_config: false , :mac => "000300111101"
-      
+
       # link for eth2 --> leaf02:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net13", auto_config: false , :mac => "000300111102"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1544,7 +1544,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1570,7 +1570,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:11:11:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:11:11:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1586,9 +1586,9 @@ end
 
   ##### DEFINE VM for server03 #####
   config.vm.define "server03" do |device|
-    
-    device.vm.hostname = "server03" 
-    
+
+    device.vm.hostname = "server03"
+
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server03"
@@ -1603,13 +1603,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp4
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net3", auto_config: false , :mac => "a00000000033"
-      
+
       # link for eth1 --> leaf03:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net22", auto_config: false , :mac => "000300333301"
-      
+
       # link for eth2 --> leaf04:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net57", auto_config: false , :mac => "000300333302"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1624,7 +1624,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1650,7 +1650,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:33:33:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:33:33:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1666,9 +1666,9 @@ end
 
   ##### DEFINE VM for server02 #####
   config.vm.define "server02" do |device|
-    
-    device.vm.hostname = "server02" 
-    
+
+    device.vm.hostname = "server02"
+
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server02"
@@ -1683,13 +1683,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp3
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net47", auto_config: false , :mac => "a00000000032"
-      
+
       # link for eth1 --> leaf01:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net12", auto_config: false , :mac => "000300222201"
-      
+
       # link for eth2 --> leaf02:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net15", auto_config: false , :mac => "000300222202"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1704,7 +1704,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1730,7 +1730,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:22:22:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:22:22:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1746,9 +1746,9 @@ end
 
   ##### DEFINE VM for server04 #####
   config.vm.define "server04" do |device|
-    
-    device.vm.hostname = "server04" 
-    
+
+    device.vm.hostname = "server04"
+
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server04"
@@ -1763,13 +1763,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp5
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net49", auto_config: false , :mac => "a00000000034"
-      
+
       # link for eth1 --> leaf03:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net19", auto_config: false , :mac => "000300444401"
-      
+
       # link for eth2 --> leaf04:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net27", auto_config: false , :mac => "000300444402"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1784,7 +1784,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1810,7 +1810,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:44:44:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:44:44:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1826,9 +1826,9 @@ end
 
   ##### DEFINE VM for internet #####
   config.vm.define "internet" do |device|
-    
-    device.vm.hostname = "internet" 
-    
+
+    device.vm.hostname = "internet"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1844,13 +1844,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp15
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net35", auto_config: false , :mac => "a00000000050"
-      
+
       # link for swp1 --> exit01:swp44
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net5", auto_config: false , :mac => "443839000007"
-      
+
       # link for swp2 --> exit02:swp44
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net39", auto_config: false , :mac => "44383900003e"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1862,7 +1862,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_internet.sh"
@@ -1888,7 +1888,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:3e --> swp2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:3e", NAME="swp2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = swp48"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="swp48", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@
 #    built with the following args: ./topology_converter.py ./topology.dot
 #
 #    NOTE: in order to use this Vagrantfile you will need:
-#       -Vagrant(v1.8.6+) installed: http://www.vagrantup.com/downloads
+#       -Vagrant(v2.0.2+) installed: http://www.vagrantup.com/downloads
 #       -the "helper_scripts" directory that comes packaged with topology-converter.py
 #       -Virtualbox installed: https://www.virtualbox.org/wiki/Downloads
 
@@ -50,7 +50,7 @@ if grep -q -i 'cumulus' /etc/lsb-release &> /dev/null; then
             echo "  INFO: Detected Cumulus Linux v$DISTRIB_RELEASE Release"
             if [[ $DISTRIB_RELEASE =~ ^3.[1-9].* ]]; then
                 echo "### Fixing ONIE DHCP to avoid Vagrant Interface ###"
-                echo "     Note: Installing from ONIE will undo these changes."
+                echo "     Note: Installing from ONIE will undo these changes." 
                 mkdir /tmp/foo
                 mount LABEL=ONIE-BOOT /tmp/foo
                 sed -i 's/eth0/eth1/g' /tmp/foo/grub/grub.cfg
@@ -86,9 +86,9 @@ Vagrant.configure("2") do |config|
 
   ##### DEFINE VM for oob-mgmt-server #####
   config.vm.define "oob-mgmt-server" do |device|
-
-    device.vm.hostname = "oob-mgmt-server"
-
+    
+    device.vm.hostname = "oob-mgmt-server" 
+    
     device.vm.box = "CumulusCommunity/vx_oob_server"
     device.vm.box_version = "1.0.4"
     device.vm.provider "virtualbox" do |v|
@@ -104,7 +104,7 @@ Vagrant.configure("2") do |config|
     # NETWORK INTERFACES
       # link for eth1 --> oob-mgmt-switch:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net54", auto_config: false , :mac => "443839000057"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -114,7 +114,7 @@ Vagrant.configure("2") do |config|
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_oob_server.sh"
@@ -132,7 +132,7 @@ device.vm.provision :shell , :inline => <<-udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:57 --> eth1"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:57", NAME="eth1", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = eth0"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="eth0", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -148,9 +148,9 @@ end
 
   ##### DEFINE VM for oob-mgmt-switch #####
   config.vm.define "oob-mgmt-switch" do |device|
-
-    device.vm.hostname = "oob-mgmt-switch"
-
+    
+    device.vm.hostname = "oob-mgmt-switch" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -166,49 +166,49 @@ end
     # NETWORK INTERFACES
       # link for swp1 --> oob-mgmt-server:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net54", auto_config: false , :mac => "a00000000061"
-
+      
       # link for swp2 --> server01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net42", auto_config: false , :mac => "443839000043"
-
+      
       # link for swp3 --> server02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net47", auto_config: false , :mac => "44383900004c"
-
+      
       # link for swp4 --> server03:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net3", auto_config: false , :mac => "443839000004"
-
+      
       # link for swp5 --> server04:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net49", auto_config: false , :mac => "44383900004e"
-
+      
       # link for swp6 --> leaf01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net20", auto_config: false , :mac => "443839000020"
-
+      
       # link for swp7 --> leaf02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net38", auto_config: false , :mac => "44383900003d"
-
+      
       # link for swp8 --> leaf03:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net28", auto_config: false , :mac => "44383900002d"
-
+      
       # link for swp9 --> leaf04:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net34", auto_config: false , :mac => "443839000037"
-
+      
       # link for swp10 --> spine01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net31", auto_config: false , :mac => "443839000032"
-
+      
       # link for swp11 --> spine02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net59", auto_config: false , :mac => "44383900005f"
-
+      
       # link for swp12 --> exit01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net9", auto_config: false , :mac => "44383900000f"
-
+      
       # link for swp13 --> exit02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net48", auto_config: false , :mac => "44383900004d"
-
+      
       # link for swp14 --> edge01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net40", auto_config: false , :mac => "443839000040"
-
+      
       # link for swp15 --> internet:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net35", auto_config: false , :mac => "443839000038"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -232,7 +232,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_oob_switch.sh"
@@ -306,7 +306,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:38 --> swp15"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:38", NAME="swp15", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = eth0"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="eth0", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -322,9 +322,9 @@ end
 
   ##### DEFINE VM for exit02 #####
   config.vm.define "exit02" do |device|
-
-    device.vm.hostname = "exit02"
-
+    
+    device.vm.hostname = "exit02" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -340,37 +340,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp13
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net48", auto_config: false , :mac => "a00000000042"
-
+      
       # link for swp1 --> edge01:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net7", auto_config: false , :mac => "44383900000c"
-
+      
       # link for swp44 --> internet:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net39", auto_config: false , :mac => "44383900003f"
-
+      
       # link for swp45 --> exit02:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net30", auto_config: false , :mac => "443839000030"
-
+      
       # link for swp46 --> exit02:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net30", auto_config: false , :mac => "443839000031"
-
+      
       # link for swp47 --> exit02:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net33", auto_config: false , :mac => "443839000035"
-
+      
       # link for swp48 --> exit02:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net33", auto_config: false , :mac => "443839000036"
-
+      
       # link for swp49 --> exit01:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net24", auto_config: false , :mac => "443839000027"
-
+      
       # link for swp50 --> exit01:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net14", auto_config: false , :mac => "443839000017"
-
+      
       # link for swp51 --> spine01:swp29
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net21", auto_config: false , :mac => "443839000021"
-
+      
       # link for swp52 --> spine02:swp29
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net53", auto_config: false , :mac => "443839000055"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -390,7 +390,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -448,7 +448,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:55 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:55", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -464,9 +464,9 @@ end
 
   ##### DEFINE VM for exit01 #####
   config.vm.define "exit01" do |device|
-
-    device.vm.hostname = "exit01"
-
+    
+    device.vm.hostname = "exit01" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -482,37 +482,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp12
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net9", auto_config: false , :mac => "a00000000041"
-
+      
       # link for swp1 --> edge01:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net46", auto_config: false , :mac => "44383900004b"
-
+      
       # link for swp44 --> internet:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net5", auto_config: false , :mac => "443839000008"
-
+      
       # link for swp45 --> exit01:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net43", auto_config: false , :mac => "443839000044"
-
+      
       # link for swp46 --> exit01:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net43", auto_config: false , :mac => "443839000045"
-
+      
       # link for swp47 --> exit01:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net11", auto_config: false , :mac => "443839000012"
-
+      
       # link for swp48 --> exit01:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net11", auto_config: false , :mac => "443839000013"
-
+      
       # link for swp49 --> exit02:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net24", auto_config: false , :mac => "443839000026"
-
+      
       # link for swp50 --> exit02:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net14", auto_config: false , :mac => "443839000016"
-
+      
       # link for swp51 --> spine01:swp30
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net6", auto_config: false , :mac => "443839000009"
-
+      
       # link for swp52 --> spine02:swp30
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net56", auto_config: false , :mac => "44383900005a"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -532,7 +532,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -590,7 +590,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:5a --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:5a", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -606,9 +606,9 @@ end
 
   ##### DEFINE VM for spine02 #####
   config.vm.define "spine02" do |device|
-
-    device.vm.hostname = "spine02"
-
+    
+    device.vm.hostname = "spine02" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -624,31 +624,31 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp11
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net59", auto_config: false , :mac => "a00000000022"
-
+      
       # link for swp1 --> leaf01:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net23", auto_config: false , :mac => "443839000025"
-
+      
       # link for swp2 --> leaf02:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net58", auto_config: false , :mac => "44383900005e"
-
+      
       # link for swp3 --> leaf03:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net17", auto_config: false , :mac => "44383900001c"
-
+      
       # link for swp4 --> leaf04:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net44", auto_config: false , :mac => "443839000047"
-
+      
       # link for swp29 --> exit02:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net53", auto_config: false , :mac => "443839000056"
-
+      
       # link for swp30 --> exit01:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net56", auto_config: false , :mac => "44383900005b"
-
+      
       # link for swp31 --> spine01:swp31
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net45", auto_config: false , :mac => "443839000049"
-
+      
       # link for swp32 --> spine01:swp32
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net36", auto_config: false , :mac => "44383900003a"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -666,7 +666,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -716,7 +716,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:3a --> swp32"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:3a", NAME="swp32", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -732,9 +732,9 @@ end
 
   ##### DEFINE VM for spine01 #####
   config.vm.define "spine01" do |device|
-
-    device.vm.hostname = "spine01"
-
+    
+    device.vm.hostname = "spine01" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -750,31 +750,31 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp10
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net31", auto_config: false , :mac => "a00000000021"
-
+      
       # link for swp1 --> leaf01:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net52", auto_config: false , :mac => "443839000054"
-
+      
       # link for swp2 --> leaf02:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net25", auto_config: false , :mac => "443839000029"
-
+      
       # link for swp3 --> leaf03:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net50", auto_config: false , :mac => "443839000050"
-
+      
       # link for swp4 --> leaf04:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net37", auto_config: false , :mac => "44383900003c"
-
+      
       # link for swp29 --> exit02:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net21", auto_config: false , :mac => "443839000022"
-
+      
       # link for swp30 --> exit01:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net6", auto_config: false , :mac => "44383900000a"
-
+      
       # link for swp31 --> spine02:swp31
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net45", auto_config: false , :mac => "443839000048"
-
+      
       # link for swp32 --> spine02:swp32
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net36", auto_config: false , :mac => "443839000039"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -792,7 +792,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -842,7 +842,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:39 --> swp32"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:39", NAME="swp32", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -858,9 +858,9 @@ end
 
   ##### DEFINE VM for leaf04 #####
   config.vm.define "leaf04" do |device|
-
-    device.vm.hostname = "leaf04"
-
+    
+    device.vm.hostname = "leaf04" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -876,37 +876,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp9
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net34", auto_config: false , :mac => "a00000000014"
-
+      
       # link for swp1 --> server03:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net57", auto_config: false , :mac => "44383900005c"
-
+      
       # link for swp2 --> server04:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net27", auto_config: false , :mac => "44383900002c"
-
+      
       # link for swp45 --> leaf04:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net16", auto_config: false , :mac => "443839000019"
-
+      
       # link for swp46 --> leaf04:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net16", auto_config: false , :mac => "44383900001a"
-
+      
       # link for swp47 --> leaf04:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net32", auto_config: false , :mac => "443839000033"
-
+      
       # link for swp48 --> leaf04:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net32", auto_config: false , :mac => "443839000034"
-
+      
       # link for swp49 --> leaf03:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net29", auto_config: false , :mac => "44383900002f"
-
+      
       # link for swp50 --> leaf03:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net4", auto_config: false , :mac => "443839000006"
-
+      
       # link for swp51 --> spine01:swp4
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net37", auto_config: false , :mac => "44383900003b"
-
+      
       # link for swp52 --> spine02:swp4
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net44", auto_config: false , :mac => "443839000046"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -926,7 +926,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -984,7 +984,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:46 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:46", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1000,9 +1000,9 @@ end
 
   ##### DEFINE VM for leaf02 #####
   config.vm.define "leaf02" do |device|
-
-    device.vm.hostname = "leaf02"
-
+    
+    device.vm.hostname = "leaf02" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1018,37 +1018,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp7
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net38", auto_config: false , :mac => "a00000000012"
-
+      
       # link for swp1 --> server01:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net13", auto_config: false , :mac => "443839000015"
-
+      
       # link for swp2 --> server02:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net15", auto_config: false , :mac => "443839000018"
-
+      
       # link for swp45 --> leaf02:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net8", auto_config: false , :mac => "44383900000d"
-
+      
       # link for swp46 --> leaf02:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net8", auto_config: false , :mac => "44383900000e"
-
+      
       # link for swp47 --> leaf02:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net55", auto_config: false , :mac => "443839000058"
-
+      
       # link for swp48 --> leaf02:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net55", auto_config: false , :mac => "443839000059"
-
+      
       # link for swp49 --> leaf01:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net10", auto_config: false , :mac => "443839000011"
-
+      
       # link for swp50 --> leaf01:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net1", auto_config: false , :mac => "443839000002"
-
+      
       # link for swp51 --> spine01:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net25", auto_config: false , :mac => "443839000028"
-
+      
       # link for swp52 --> spine02:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net58", auto_config: false , :mac => "44383900005d"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1068,7 +1068,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1126,7 +1126,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:5d --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:5d", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1142,9 +1142,9 @@ end
 
   ##### DEFINE VM for leaf03 #####
   config.vm.define "leaf03" do |device|
-
-    device.vm.hostname = "leaf03"
-
+    
+    device.vm.hostname = "leaf03" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1160,37 +1160,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp8
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net28", auto_config: false , :mac => "a00000000013"
-
+      
       # link for swp1 --> server03:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net22", auto_config: false , :mac => "443839000023"
-
+      
       # link for swp2 --> server04:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net19", auto_config: false , :mac => "44383900001f"
-
+      
       # link for swp45 --> leaf03:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net26", auto_config: false , :mac => "44383900002a"
-
+      
       # link for swp46 --> leaf03:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net26", auto_config: false , :mac => "44383900002b"
-
+      
       # link for swp47 --> leaf03:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net51", auto_config: false , :mac => "443839000051"
-
+      
       # link for swp48 --> leaf03:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net51", auto_config: false , :mac => "443839000052"
-
+      
       # link for swp49 --> leaf04:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net29", auto_config: false , :mac => "44383900002e"
-
+      
       # link for swp50 --> leaf04:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net4", auto_config: false , :mac => "443839000005"
-
+      
       # link for swp51 --> spine01:swp3
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net50", auto_config: false , :mac => "44383900004f"
-
+      
       # link for swp52 --> spine02:swp3
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net17", auto_config: false , :mac => "44383900001b"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1210,7 +1210,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1268,7 +1268,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:1b --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:1b", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1284,9 +1284,9 @@ end
 
   ##### DEFINE VM for leaf01 #####
   config.vm.define "leaf01" do |device|
-
-    device.vm.hostname = "leaf01"
-
+    
+    device.vm.hostname = "leaf01" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1302,37 +1302,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp6
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net20", auto_config: false , :mac => "a00000000011"
-
+      
       # link for swp1 --> server01:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net2", auto_config: false , :mac => "443839000003"
-
+      
       # link for swp2 --> server02:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net12", auto_config: false , :mac => "443839000014"
-
+      
       # link for swp45 --> leaf01:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net18", auto_config: false , :mac => "44383900001d"
-
+      
       # link for swp46 --> leaf01:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net18", auto_config: false , :mac => "44383900001e"
-
+      
       # link for swp47 --> leaf01:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net41", auto_config: false , :mac => "443839000041"
-
+      
       # link for swp48 --> leaf01:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net41", auto_config: false , :mac => "443839000042"
-
+      
       # link for swp49 --> leaf02:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net10", auto_config: false , :mac => "443839000010"
-
+      
       # link for swp50 --> leaf02:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net1", auto_config: false , :mac => "443839000001"
-
+      
       # link for swp51 --> spine01:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net52", auto_config: false , :mac => "443839000053"
-
+      
       # link for swp52 --> spine02:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net23", auto_config: false , :mac => "443839000024"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1352,7 +1352,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1410,7 +1410,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:24 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:24", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1426,9 +1426,9 @@ end
 
   ##### DEFINE VM for edge01 #####
   config.vm.define "edge01" do |device|
-
-    device.vm.hostname = "edge01"
-
+    
+    device.vm.hostname = "edge01" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_edge01"
@@ -1443,13 +1443,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp14
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net40", auto_config: false , :mac => "a00000000051"
-
+      
       # link for eth1 --> exit01:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net46", auto_config: false , :mac => "44383900004a"
-
+      
       # link for eth2 --> exit02:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net7", auto_config: false , :mac => "44383900000b"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1464,7 +1464,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1490,7 +1490,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:0b --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:0b", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1506,9 +1506,9 @@ end
 
   ##### DEFINE VM for server01 #####
   config.vm.define "server01" do |device|
-
-    device.vm.hostname = "server01"
-
+    
+    device.vm.hostname = "server01" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server01"
@@ -1523,13 +1523,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net42", auto_config: false , :mac => "a00000000031"
-
+      
       # link for eth1 --> leaf01:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net2", auto_config: false , :mac => "000300111101"
-
+      
       # link for eth2 --> leaf02:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net13", auto_config: false , :mac => "000300111102"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1544,7 +1544,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1570,7 +1570,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:11:11:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:11:11:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1586,9 +1586,9 @@ end
 
   ##### DEFINE VM for server03 #####
   config.vm.define "server03" do |device|
-
-    device.vm.hostname = "server03"
-
+    
+    device.vm.hostname = "server03" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server03"
@@ -1603,13 +1603,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp4
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net3", auto_config: false , :mac => "a00000000033"
-
+      
       # link for eth1 --> leaf03:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net22", auto_config: false , :mac => "000300333301"
-
+      
       # link for eth2 --> leaf04:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net57", auto_config: false , :mac => "000300333302"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1624,7 +1624,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1650,7 +1650,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:33:33:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:33:33:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1666,9 +1666,9 @@ end
 
   ##### DEFINE VM for server02 #####
   config.vm.define "server02" do |device|
-
-    device.vm.hostname = "server02"
-
+    
+    device.vm.hostname = "server02" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server02"
@@ -1683,13 +1683,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp3
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net47", auto_config: false , :mac => "a00000000032"
-
+      
       # link for eth1 --> leaf01:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net12", auto_config: false , :mac => "000300222201"
-
+      
       # link for eth2 --> leaf02:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net15", auto_config: false , :mac => "000300222202"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1704,7 +1704,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1730,7 +1730,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:22:22:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:22:22:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1746,9 +1746,9 @@ end
 
   ##### DEFINE VM for server04 #####
   config.vm.define "server04" do |device|
-
-    device.vm.hostname = "server04"
-
+    
+    device.vm.hostname = "server04" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server04"
@@ -1763,13 +1763,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp5
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net49", auto_config: false , :mac => "a00000000034"
-
+      
       # link for eth1 --> leaf03:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net19", auto_config: false , :mac => "000300444401"
-
+      
       # link for eth2 --> leaf04:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net27", auto_config: false , :mac => "000300444402"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1784,7 +1784,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1810,7 +1810,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:44:44:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:44:44:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1826,9 +1826,9 @@ end
 
   ##### DEFINE VM for internet #####
   config.vm.define "internet" do |device|
-
-    device.vm.hostname = "internet"
-
+    
+    device.vm.hostname = "internet" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1844,13 +1844,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp15
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net35", auto_config: false , :mac => "a00000000050"
-
+      
       # link for swp1 --> exit01:swp44
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net5", auto_config: false , :mac => "443839000007"
-
+      
       # link for swp2 --> exit02:swp44
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net39", auto_config: false , :mac => "44383900003e"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1862,7 +1862,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_internet.sh"
@@ -1888,7 +1888,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:3e --> swp2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:3e", NAME="swp2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = swp48"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="swp48", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules

--- a/Vagrantfile-kvm
+++ b/Vagrantfile-kvm
@@ -5,7 +5,7 @@
 #    built with the following args: ./topology_converter.py ./topology.dot -p libvirt
 #
 #    NOTE: in order to use this Vagrantfile you will need:
-#       -Vagrant(v1.8.6+) installed: http://www.vagrantup.com/downloads
+#       -Vagrant(v2.0.2+) installed: http://www.vagrantup.com/downloads
 #       -the "helper_scripts" directory that comes packaged with topology-converter.py
 #        -Libvirt Installed -- guide to come
 #       -Vagrant-Libvirt Plugin installed: $ vagrant plugin install vagrant-libvirt
@@ -66,7 +66,7 @@ if grep -q -i 'cumulus' /etc/lsb-release &> /dev/null; then
             echo "  INFO: Detected Cumulus Linux v$DISTRIB_RELEASE Release"
             if [[ $DISTRIB_RELEASE =~ ^3.[1-9].* ]]; then
                 echo "### Fixing ONIE DHCP to avoid Vagrant Interface ###"
-                echo "     Note: Installing from ONIE will undo these changes."
+                echo "     Note: Installing from ONIE will undo these changes." 
                 mkdir /tmp/foo
                 mount LABEL=ONIE-BOOT /tmp/foo
                 sed -i 's/eth0/eth1/g' /tmp/foo/grub/grub.cfg
@@ -100,9 +100,9 @@ Vagrant.configure("2") do |config|
 
   ##### DEFINE VM for oob-mgmt-server #####
   config.vm.define "oob-mgmt-server" do |device|
-
-    device.vm.hostname = "oob-mgmt-server"
-
+    
+    device.vm.hostname = "oob-mgmt-server" 
+    
     device.vm.box = "CumulusCommunity/vx_oob_server"
     device.vm.box_version = "1.0.4"
 
@@ -131,7 +131,7 @@ Vagrant.configure("2") do |config|
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_oob_server.sh"
@@ -149,7 +149,7 @@ device.vm.provision :shell , :inline => <<-udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:57 --> eth1"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:57", NAME="eth1", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = eth0"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="eth0", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -165,9 +165,9 @@ end
 
   ##### DEFINE VM for oob-mgmt-switch #####
   config.vm.define "oob-mgmt-switch" do |device|
-
-    device.vm.hostname = "oob-mgmt-switch"
-
+    
+    device.vm.hostname = "oob-mgmt-switch" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -336,7 +336,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_oob_switch.sh"
@@ -410,7 +410,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:38 --> swp15"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:38", NAME="swp15", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = eth0"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="eth0", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -426,9 +426,9 @@ end
 
   ##### DEFINE VM for exit02 #####
   config.vm.define "exit02" do |device|
-
-    device.vm.hostname = "exit02"
-
+    
+    device.vm.hostname = "exit02" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -557,7 +557,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -615,7 +615,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:55 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:55", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -631,9 +631,9 @@ end
 
   ##### DEFINE VM for exit01 #####
   config.vm.define "exit01" do |device|
-
-    device.vm.hostname = "exit01"
-
+    
+    device.vm.hostname = "exit01" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -762,7 +762,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -820,7 +820,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:5a --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:5a", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -836,9 +836,9 @@ end
 
   ##### DEFINE VM for spine02 #####
   config.vm.define "spine02" do |device|
-
-    device.vm.hostname = "spine02"
-
+    
+    device.vm.hostname = "spine02" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -947,7 +947,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -997,7 +997,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:3a --> swp32"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:3a", NAME="swp32", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1013,9 +1013,9 @@ end
 
   ##### DEFINE VM for spine01 #####
   config.vm.define "spine01" do |device|
-
-    device.vm.hostname = "spine01"
-
+    
+    device.vm.hostname = "spine01" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -1124,7 +1124,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1174,7 +1174,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:39 --> swp32"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:39", NAME="swp32", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1190,9 +1190,9 @@ end
 
   ##### DEFINE VM for leaf04 #####
   config.vm.define "leaf04" do |device|
-
-    device.vm.hostname = "leaf04"
-
+    
+    device.vm.hostname = "leaf04" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -1321,7 +1321,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1379,7 +1379,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:46 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:46", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1395,9 +1395,9 @@ end
 
   ##### DEFINE VM for leaf02 #####
   config.vm.define "leaf02" do |device|
-
-    device.vm.hostname = "leaf02"
-
+    
+    device.vm.hostname = "leaf02" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -1526,7 +1526,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1584,7 +1584,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:5d --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:5d", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1600,9 +1600,9 @@ end
 
   ##### DEFINE VM for leaf03 #####
   config.vm.define "leaf03" do |device|
-
-    device.vm.hostname = "leaf03"
-
+    
+    device.vm.hostname = "leaf03" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -1731,7 +1731,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1789,7 +1789,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:1b --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:1b", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1805,9 +1805,9 @@ end
 
   ##### DEFINE VM for leaf01 #####
   config.vm.define "leaf01" do |device|
-
-    device.vm.hostname = "leaf01"
-
+    
+    device.vm.hostname = "leaf01" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -1936,7 +1936,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1994,7 +1994,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:24 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:24", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2010,13 +2010,13 @@ end
 
   ##### DEFINE VM for edge01 #####
   config.vm.define "edge01" do |device|
-
-    device.vm.hostname = "edge01"
-
+    
+    device.vm.hostname = "edge01" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
 
     device.vm.provider :libvirt do |v|
-      v.nic_model_type = 'e1000'
+      v.nic_model_type = 'e1000' 
       v.memory = 768
     end
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
@@ -2064,7 +2064,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -2090,7 +2090,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:0b --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:0b", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2106,13 +2106,13 @@ end
 
   ##### DEFINE VM for server01 #####
   config.vm.define "server01" do |device|
-
-    device.vm.hostname = "server01"
-
+    
+    device.vm.hostname = "server01" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
 
     device.vm.provider :libvirt do |v|
-      v.nic_model_type = 'e1000'
+      v.nic_model_type = 'e1000' 
       v.memory = 512
     end
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
@@ -2160,7 +2160,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -2186,7 +2186,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:11:11:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:11:11:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2202,13 +2202,13 @@ end
 
   ##### DEFINE VM for server03 #####
   config.vm.define "server03" do |device|
-
-    device.vm.hostname = "server03"
-
+    
+    device.vm.hostname = "server03" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
 
     device.vm.provider :libvirt do |v|
-      v.nic_model_type = 'e1000'
+      v.nic_model_type = 'e1000' 
       v.memory = 512
     end
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
@@ -2256,7 +2256,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -2282,7 +2282,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:33:33:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:33:33:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2298,13 +2298,13 @@ end
 
   ##### DEFINE VM for server02 #####
   config.vm.define "server02" do |device|
-
-    device.vm.hostname = "server02"
-
+    
+    device.vm.hostname = "server02" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
 
     device.vm.provider :libvirt do |v|
-      v.nic_model_type = 'e1000'
+      v.nic_model_type = 'e1000' 
       v.memory = 512
     end
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
@@ -2352,7 +2352,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -2378,7 +2378,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:22:22:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:22:22:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2394,13 +2394,13 @@ end
 
   ##### DEFINE VM for server04 #####
   config.vm.define "server04" do |device|
-
-    device.vm.hostname = "server04"
-
+    
+    device.vm.hostname = "server04" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
 
     device.vm.provider :libvirt do |v|
-      v.nic_model_type = 'e1000'
+      v.nic_model_type = 'e1000' 
       v.memory = 512
     end
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
@@ -2448,7 +2448,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -2474,7 +2474,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:44:44:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:44:44:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2490,9 +2490,9 @@ end
 
   ##### DEFINE VM for internet #####
   config.vm.define "internet" do |device|
-
-    device.vm.hostname = "internet"
-
+    
+    device.vm.hostname = "internet" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -2541,7 +2541,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_internet.sh"
@@ -2567,7 +2567,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:3e --> swp2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:3e", NAME="swp2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = swp48"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="swp48", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules

--- a/Vagrantfile-kvm
+++ b/Vagrantfile-kvm
@@ -27,7 +27,7 @@ exit unless REQUIRED_PLUGINS_LIBVIRT.all? do |plugin|
   )
 end
 
-Vagrant.require_version ">= 1.8.6"
+Vagrant.require_version ">= 2.0.2"
 
 $script = <<-SCRIPT
 if grep -q -i 'cumulus' /etc/lsb-release &> /dev/null; then
@@ -66,7 +66,7 @@ if grep -q -i 'cumulus' /etc/lsb-release &> /dev/null; then
             echo "  INFO: Detected Cumulus Linux v$DISTRIB_RELEASE Release"
             if [[ $DISTRIB_RELEASE =~ ^3.[1-9].* ]]; then
                 echo "### Fixing ONIE DHCP to avoid Vagrant Interface ###"
-                echo "     Note: Installing from ONIE will undo these changes." 
+                echo "     Note: Installing from ONIE will undo these changes."
                 mkdir /tmp/foo
                 mount LABEL=ONIE-BOOT /tmp/foo
                 sed -i 's/eth0/eth1/g' /tmp/foo/grub/grub.cfg
@@ -100,9 +100,9 @@ Vagrant.configure("2") do |config|
 
   ##### DEFINE VM for oob-mgmt-server #####
   config.vm.define "oob-mgmt-server" do |device|
-    
-    device.vm.hostname = "oob-mgmt-server" 
-    
+
+    device.vm.hostname = "oob-mgmt-server"
+
     device.vm.box = "CumulusCommunity/vx_oob_server"
     device.vm.box_version = "1.0.4"
 
@@ -131,7 +131,7 @@ Vagrant.configure("2") do |config|
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_oob_server.sh"
@@ -149,7 +149,7 @@ device.vm.provision :shell , :inline => <<-udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:57 --> eth1"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:57", NAME="eth1", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = eth0"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="eth0", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -165,9 +165,9 @@ end
 
   ##### DEFINE VM for oob-mgmt-switch #####
   config.vm.define "oob-mgmt-switch" do |device|
-    
-    device.vm.hostname = "oob-mgmt-switch" 
-    
+
+    device.vm.hostname = "oob-mgmt-switch"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -336,7 +336,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_oob_switch.sh"
@@ -410,7 +410,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:38 --> swp15"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:38", NAME="swp15", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = eth0"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="eth0", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -426,9 +426,9 @@ end
 
   ##### DEFINE VM for exit02 #####
   config.vm.define "exit02" do |device|
-    
-    device.vm.hostname = "exit02" 
-    
+
+    device.vm.hostname = "exit02"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -557,7 +557,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -615,7 +615,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:55 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:55", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -631,9 +631,9 @@ end
 
   ##### DEFINE VM for exit01 #####
   config.vm.define "exit01" do |device|
-    
-    device.vm.hostname = "exit01" 
-    
+
+    device.vm.hostname = "exit01"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -762,7 +762,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -820,7 +820,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:5a --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:5a", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -836,9 +836,9 @@ end
 
   ##### DEFINE VM for spine02 #####
   config.vm.define "spine02" do |device|
-    
-    device.vm.hostname = "spine02" 
-    
+
+    device.vm.hostname = "spine02"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -947,7 +947,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -997,7 +997,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:3a --> swp32"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:3a", NAME="swp32", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1013,9 +1013,9 @@ end
 
   ##### DEFINE VM for spine01 #####
   config.vm.define "spine01" do |device|
-    
-    device.vm.hostname = "spine01" 
-    
+
+    device.vm.hostname = "spine01"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -1124,7 +1124,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1174,7 +1174,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:39 --> swp32"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:39", NAME="swp32", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1190,9 +1190,9 @@ end
 
   ##### DEFINE VM for leaf04 #####
   config.vm.define "leaf04" do |device|
-    
-    device.vm.hostname = "leaf04" 
-    
+
+    device.vm.hostname = "leaf04"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -1321,7 +1321,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1379,7 +1379,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:46 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:46", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1395,9 +1395,9 @@ end
 
   ##### DEFINE VM for leaf02 #####
   config.vm.define "leaf02" do |device|
-    
-    device.vm.hostname = "leaf02" 
-    
+
+    device.vm.hostname = "leaf02"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -1526,7 +1526,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1584,7 +1584,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:5d --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:5d", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1600,9 +1600,9 @@ end
 
   ##### DEFINE VM for leaf03 #####
   config.vm.define "leaf03" do |device|
-    
-    device.vm.hostname = "leaf03" 
-    
+
+    device.vm.hostname = "leaf03"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -1731,7 +1731,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1789,7 +1789,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:1b --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:1b", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1805,9 +1805,9 @@ end
 
   ##### DEFINE VM for leaf01 #####
   config.vm.define "leaf01" do |device|
-    
-    device.vm.hostname = "leaf01" 
-    
+
+    device.vm.hostname = "leaf01"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -1936,7 +1936,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1994,7 +1994,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:24 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:24", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2010,13 +2010,13 @@ end
 
   ##### DEFINE VM for edge01 #####
   config.vm.define "edge01" do |device|
-    
-    device.vm.hostname = "edge01" 
-    
+
+    device.vm.hostname = "edge01"
+
     device.vm.box = "yk0/ubuntu-xenial"
 
     device.vm.provider :libvirt do |v|
-      v.nic_model_type = 'e1000' 
+      v.nic_model_type = 'e1000'
       v.memory = 768
     end
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
@@ -2064,7 +2064,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -2090,7 +2090,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:0b --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:0b", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2106,13 +2106,13 @@ end
 
   ##### DEFINE VM for server01 #####
   config.vm.define "server01" do |device|
-    
-    device.vm.hostname = "server01" 
-    
+
+    device.vm.hostname = "server01"
+
     device.vm.box = "yk0/ubuntu-xenial"
 
     device.vm.provider :libvirt do |v|
-      v.nic_model_type = 'e1000' 
+      v.nic_model_type = 'e1000'
       v.memory = 512
     end
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
@@ -2160,7 +2160,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -2186,7 +2186,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:11:11:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:11:11:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2202,13 +2202,13 @@ end
 
   ##### DEFINE VM for server03 #####
   config.vm.define "server03" do |device|
-    
-    device.vm.hostname = "server03" 
-    
+
+    device.vm.hostname = "server03"
+
     device.vm.box = "yk0/ubuntu-xenial"
 
     device.vm.provider :libvirt do |v|
-      v.nic_model_type = 'e1000' 
+      v.nic_model_type = 'e1000'
       v.memory = 512
     end
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
@@ -2256,7 +2256,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -2282,7 +2282,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:33:33:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:33:33:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2298,13 +2298,13 @@ end
 
   ##### DEFINE VM for server02 #####
   config.vm.define "server02" do |device|
-    
-    device.vm.hostname = "server02" 
-    
+
+    device.vm.hostname = "server02"
+
     device.vm.box = "yk0/ubuntu-xenial"
 
     device.vm.provider :libvirt do |v|
-      v.nic_model_type = 'e1000' 
+      v.nic_model_type = 'e1000'
       v.memory = 512
     end
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
@@ -2352,7 +2352,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -2378,7 +2378,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:22:22:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:22:22:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2394,13 +2394,13 @@ end
 
   ##### DEFINE VM for server04 #####
   config.vm.define "server04" do |device|
-    
-    device.vm.hostname = "server04" 
-    
+
+    device.vm.hostname = "server04"
+
     device.vm.box = "yk0/ubuntu-xenial"
 
     device.vm.provider :libvirt do |v|
-      v.nic_model_type = 'e1000' 
+      v.nic_model_type = 'e1000'
       v.memory = 512
     end
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
@@ -2448,7 +2448,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -2474,7 +2474,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:44:44:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:44:44:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2490,9 +2490,9 @@ end
 
   ##### DEFINE VM for internet #####
   config.vm.define "internet" do |device|
-    
-    device.vm.hostname = "internet" 
-    
+
+    device.vm.hostname = "internet"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -2541,7 +2541,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_internet.sh"
@@ -2567,7 +2567,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:3e --> swp2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:3e", NAME="swp2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = swp48"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="swp48", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules

--- a/Vagrantfile-large-memory-libvirt
+++ b/Vagrantfile-large-memory-libvirt
@@ -27,7 +27,7 @@ exit unless REQUIRED_PLUGINS_LIBVIRT.all? do |plugin|
   )
 end
 
-Vagrant.require_version ">= 1.8.6"
+Vagrant.require_version ">= 2.0.2"
 
 $script = <<-SCRIPT
 if grep -q -i 'cumulus' /etc/lsb-release &> /dev/null; then
@@ -66,7 +66,7 @@ if grep -q -i 'cumulus' /etc/lsb-release &> /dev/null; then
             echo "  INFO: Detected Cumulus Linux v$DISTRIB_RELEASE Release"
             if [[ $DISTRIB_RELEASE =~ ^3.[1-9].* ]]; then
                 echo "### Fixing ONIE DHCP to avoid Vagrant Interface ###"
-                echo "     Note: Installing from ONIE will undo these changes." 
+                echo "     Note: Installing from ONIE will undo these changes."
                 mkdir /tmp/foo
                 mount LABEL=ONIE-BOOT /tmp/foo
                 sed -i 's/eth0/eth1/g' /tmp/foo/grub/grub.cfg
@@ -100,9 +100,9 @@ Vagrant.configure("2") do |config|
 
   ##### DEFINE VM for oob-mgmt-server #####
   config.vm.define "oob-mgmt-server" do |device|
-    
-    device.vm.hostname = "oob-mgmt-server" 
-    
+
+    device.vm.hostname = "oob-mgmt-server"
+
     device.vm.box = "CumulusCommunity/vx_oob_server"
     device.vm.box_version = "1.0.3"
 
@@ -131,7 +131,7 @@ Vagrant.configure("2") do |config|
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_oob_server.sh"
@@ -149,7 +149,7 @@ device.vm.provision :shell , :inline => <<-udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:57 --> eth1"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:57", NAME="eth1", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = eth0"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="eth0", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -165,9 +165,9 @@ end
 
   ##### DEFINE VM for oob-mgmt-switch #####
   config.vm.define "oob-mgmt-switch" do |device|
-    
-    device.vm.hostname = "oob-mgmt-switch" 
-    
+
+    device.vm.hostname = "oob-mgmt-switch"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -336,7 +336,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_oob_switch.sh"
@@ -410,7 +410,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:38 --> swp15"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:38", NAME="swp15", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = eth0"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="eth0", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -426,9 +426,9 @@ end
 
   ##### DEFINE VM for exit02 #####
   config.vm.define "exit02" do |device|
-    
-    device.vm.hostname = "exit02" 
-    
+
+    device.vm.hostname = "exit02"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -557,7 +557,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -615,7 +615,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:55 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:55", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -631,9 +631,9 @@ end
 
   ##### DEFINE VM for exit01 #####
   config.vm.define "exit01" do |device|
-    
-    device.vm.hostname = "exit01" 
-    
+
+    device.vm.hostname = "exit01"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -762,7 +762,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -820,7 +820,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:5a --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:5a", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -836,9 +836,9 @@ end
 
   ##### DEFINE VM for spine02 #####
   config.vm.define "spine02" do |device|
-    
-    device.vm.hostname = "spine02" 
-    
+
+    device.vm.hostname = "spine02"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -947,7 +947,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -997,7 +997,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:3a --> swp32"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:3a", NAME="swp32", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1013,9 +1013,9 @@ end
 
   ##### DEFINE VM for spine01 #####
   config.vm.define "spine01" do |device|
-    
-    device.vm.hostname = "spine01" 
-    
+
+    device.vm.hostname = "spine01"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -1124,7 +1124,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1174,7 +1174,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:39 --> swp32"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:39", NAME="swp32", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1190,9 +1190,9 @@ end
 
   ##### DEFINE VM for leaf04 #####
   config.vm.define "leaf04" do |device|
-    
-    device.vm.hostname = "leaf04" 
-    
+
+    device.vm.hostname = "leaf04"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -1321,7 +1321,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1379,7 +1379,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:46 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:46", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1395,9 +1395,9 @@ end
 
   ##### DEFINE VM for leaf02 #####
   config.vm.define "leaf02" do |device|
-    
-    device.vm.hostname = "leaf02" 
-    
+
+    device.vm.hostname = "leaf02"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -1526,7 +1526,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1584,7 +1584,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:5d --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:5d", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1600,9 +1600,9 @@ end
 
   ##### DEFINE VM for leaf03 #####
   config.vm.define "leaf03" do |device|
-    
-    device.vm.hostname = "leaf03" 
-    
+
+    device.vm.hostname = "leaf03"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -1731,7 +1731,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1789,7 +1789,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:1b --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:1b", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1805,9 +1805,9 @@ end
 
   ##### DEFINE VM for leaf01 #####
   config.vm.define "leaf01" do |device|
-    
-    device.vm.hostname = "leaf01" 
-    
+
+    device.vm.hostname = "leaf01"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -1936,7 +1936,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1994,7 +1994,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:24 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:24", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2010,13 +2010,13 @@ end
 
   ##### DEFINE VM for edge01 #####
   config.vm.define "edge01" do |device|
-    
-    device.vm.hostname = "edge01" 
-    
+
+    device.vm.hostname = "edge01"
+
     device.vm.box = "yk0/ubuntu-xenial"
 
     device.vm.provider :libvirt do |v|
-      v.nic_model_type = 'e1000' 
+      v.nic_model_type = 'e1000'
       v.memory = 768
     end
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
@@ -2064,7 +2064,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -2090,7 +2090,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:0b --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:0b", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2106,13 +2106,13 @@ end
 
   ##### DEFINE VM for server01 #####
   config.vm.define "server01" do |device|
-    
-    device.vm.hostname = "server01" 
-    
+
+    device.vm.hostname = "server01"
+
     device.vm.box = "yk0/ubuntu-xenial"
 
     device.vm.provider :libvirt do |v|
-      v.nic_model_type = 'e1000' 
+      v.nic_model_type = 'e1000'
       v.memory = 3000
     end
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
@@ -2160,7 +2160,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -2186,7 +2186,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:11:11:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:11:11:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2202,13 +2202,13 @@ end
 
   ##### DEFINE VM for server03 #####
   config.vm.define "server03" do |device|
-    
-    device.vm.hostname = "server03" 
-    
+
+    device.vm.hostname = "server03"
+
     device.vm.box = "yk0/ubuntu-xenial"
 
     device.vm.provider :libvirt do |v|
-      v.nic_model_type = 'e1000' 
+      v.nic_model_type = 'e1000'
       v.memory = 3000
     end
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
@@ -2256,7 +2256,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -2282,7 +2282,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:33:33:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:33:33:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2298,13 +2298,13 @@ end
 
   ##### DEFINE VM for server02 #####
   config.vm.define "server02" do |device|
-    
-    device.vm.hostname = "server02" 
-    
+
+    device.vm.hostname = "server02"
+
     device.vm.box = "yk0/ubuntu-xenial"
 
     device.vm.provider :libvirt do |v|
-      v.nic_model_type = 'e1000' 
+      v.nic_model_type = 'e1000'
       v.memory = 3000
     end
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
@@ -2352,7 +2352,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -2378,7 +2378,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:22:22:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:22:22:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2394,13 +2394,13 @@ end
 
   ##### DEFINE VM for server04 #####
   config.vm.define "server04" do |device|
-    
-    device.vm.hostname = "server04" 
-    
+
+    device.vm.hostname = "server04"
+
     device.vm.box = "yk0/ubuntu-xenial"
 
     device.vm.provider :libvirt do |v|
-      v.nic_model_type = 'e1000' 
+      v.nic_model_type = 'e1000'
       v.memory = 3000
     end
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
@@ -2448,7 +2448,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -2474,7 +2474,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:44:44:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:44:44:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2490,9 +2490,9 @@ end
 
   ##### DEFINE VM for internet #####
   config.vm.define "internet" do |device|
-    
-    device.vm.hostname = "internet" 
-    
+
+    device.vm.hostname = "internet"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -2541,7 +2541,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_internet.sh"
@@ -2567,7 +2567,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:3e --> swp2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:3e", NAME="swp2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = swp48"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="swp48", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules

--- a/Vagrantfile-large-memory-libvirt
+++ b/Vagrantfile-large-memory-libvirt
@@ -5,7 +5,7 @@
 #    built with the following args: ./topology_converter.py ./topology_large_memory.dot -p libvirt
 #
 #    NOTE: in order to use this Vagrantfile you will need:
-#       -Vagrant(v1.8.6+) installed: http://www.vagrantup.com/downloads
+#       -Vagrant(v2.0.2+) installed: http://www.vagrantup.com/downloads
 #       -the "helper_scripts" directory that comes packaged with topology-converter.py
 #        -Libvirt Installed -- guide to come
 #       -Vagrant-Libvirt Plugin installed: $ vagrant plugin install vagrant-libvirt
@@ -66,7 +66,7 @@ if grep -q -i 'cumulus' /etc/lsb-release &> /dev/null; then
             echo "  INFO: Detected Cumulus Linux v$DISTRIB_RELEASE Release"
             if [[ $DISTRIB_RELEASE =~ ^3.[1-9].* ]]; then
                 echo "### Fixing ONIE DHCP to avoid Vagrant Interface ###"
-                echo "     Note: Installing from ONIE will undo these changes."
+                echo "     Note: Installing from ONIE will undo these changes." 
                 mkdir /tmp/foo
                 mount LABEL=ONIE-BOOT /tmp/foo
                 sed -i 's/eth0/eth1/g' /tmp/foo/grub/grub.cfg
@@ -100,9 +100,9 @@ Vagrant.configure("2") do |config|
 
   ##### DEFINE VM for oob-mgmt-server #####
   config.vm.define "oob-mgmt-server" do |device|
-
-    device.vm.hostname = "oob-mgmt-server"
-
+    
+    device.vm.hostname = "oob-mgmt-server" 
+    
     device.vm.box = "CumulusCommunity/vx_oob_server"
     device.vm.box_version = "1.0.3"
 
@@ -131,7 +131,7 @@ Vagrant.configure("2") do |config|
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_oob_server.sh"
@@ -149,7 +149,7 @@ device.vm.provision :shell , :inline => <<-udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:57 --> eth1"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:57", NAME="eth1", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = eth0"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="eth0", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -165,9 +165,9 @@ end
 
   ##### DEFINE VM for oob-mgmt-switch #####
   config.vm.define "oob-mgmt-switch" do |device|
-
-    device.vm.hostname = "oob-mgmt-switch"
-
+    
+    device.vm.hostname = "oob-mgmt-switch" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -336,7 +336,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_oob_switch.sh"
@@ -410,7 +410,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:38 --> swp15"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:38", NAME="swp15", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = eth0"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="eth0", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -426,9 +426,9 @@ end
 
   ##### DEFINE VM for exit02 #####
   config.vm.define "exit02" do |device|
-
-    device.vm.hostname = "exit02"
-
+    
+    device.vm.hostname = "exit02" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -557,7 +557,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -615,7 +615,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:55 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:55", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -631,9 +631,9 @@ end
 
   ##### DEFINE VM for exit01 #####
   config.vm.define "exit01" do |device|
-
-    device.vm.hostname = "exit01"
-
+    
+    device.vm.hostname = "exit01" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -762,7 +762,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -820,7 +820,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:5a --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:5a", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -836,9 +836,9 @@ end
 
   ##### DEFINE VM for spine02 #####
   config.vm.define "spine02" do |device|
-
-    device.vm.hostname = "spine02"
-
+    
+    device.vm.hostname = "spine02" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -947,7 +947,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -997,7 +997,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:3a --> swp32"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:3a", NAME="swp32", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1013,9 +1013,9 @@ end
 
   ##### DEFINE VM for spine01 #####
   config.vm.define "spine01" do |device|
-
-    device.vm.hostname = "spine01"
-
+    
+    device.vm.hostname = "spine01" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -1124,7 +1124,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1174,7 +1174,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:39 --> swp32"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:39", NAME="swp32", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1190,9 +1190,9 @@ end
 
   ##### DEFINE VM for leaf04 #####
   config.vm.define "leaf04" do |device|
-
-    device.vm.hostname = "leaf04"
-
+    
+    device.vm.hostname = "leaf04" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -1321,7 +1321,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1379,7 +1379,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:46 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:46", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1395,9 +1395,9 @@ end
 
   ##### DEFINE VM for leaf02 #####
   config.vm.define "leaf02" do |device|
-
-    device.vm.hostname = "leaf02"
-
+    
+    device.vm.hostname = "leaf02" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -1526,7 +1526,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1584,7 +1584,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:5d --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:5d", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1600,9 +1600,9 @@ end
 
   ##### DEFINE VM for leaf03 #####
   config.vm.define "leaf03" do |device|
-
-    device.vm.hostname = "leaf03"
-
+    
+    device.vm.hostname = "leaf03" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -1731,7 +1731,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1789,7 +1789,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:1b --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:1b", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1805,9 +1805,9 @@ end
 
   ##### DEFINE VM for leaf01 #####
   config.vm.define "leaf01" do |device|
-
-    device.vm.hostname = "leaf01"
-
+    
+    device.vm.hostname = "leaf01" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -1936,7 +1936,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1994,7 +1994,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:24 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:24", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2010,13 +2010,13 @@ end
 
   ##### DEFINE VM for edge01 #####
   config.vm.define "edge01" do |device|
-
-    device.vm.hostname = "edge01"
-
+    
+    device.vm.hostname = "edge01" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
 
     device.vm.provider :libvirt do |v|
-      v.nic_model_type = 'e1000'
+      v.nic_model_type = 'e1000' 
       v.memory = 768
     end
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
@@ -2064,7 +2064,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -2090,7 +2090,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:0b --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:0b", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2106,13 +2106,13 @@ end
 
   ##### DEFINE VM for server01 #####
   config.vm.define "server01" do |device|
-
-    device.vm.hostname = "server01"
-
+    
+    device.vm.hostname = "server01" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
 
     device.vm.provider :libvirt do |v|
-      v.nic_model_type = 'e1000'
+      v.nic_model_type = 'e1000' 
       v.memory = 3000
     end
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
@@ -2160,7 +2160,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -2186,7 +2186,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:11:11:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:11:11:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2202,13 +2202,13 @@ end
 
   ##### DEFINE VM for server03 #####
   config.vm.define "server03" do |device|
-
-    device.vm.hostname = "server03"
-
+    
+    device.vm.hostname = "server03" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
 
     device.vm.provider :libvirt do |v|
-      v.nic_model_type = 'e1000'
+      v.nic_model_type = 'e1000' 
       v.memory = 3000
     end
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
@@ -2256,7 +2256,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -2282,7 +2282,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:33:33:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:33:33:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2298,13 +2298,13 @@ end
 
   ##### DEFINE VM for server02 #####
   config.vm.define "server02" do |device|
-
-    device.vm.hostname = "server02"
-
+    
+    device.vm.hostname = "server02" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
 
     device.vm.provider :libvirt do |v|
-      v.nic_model_type = 'e1000'
+      v.nic_model_type = 'e1000' 
       v.memory = 3000
     end
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
@@ -2352,7 +2352,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -2378,7 +2378,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:22:22:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:22:22:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2394,13 +2394,13 @@ end
 
   ##### DEFINE VM for server04 #####
   config.vm.define "server04" do |device|
-
-    device.vm.hostname = "server04"
-
+    
+    device.vm.hostname = "server04" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
 
     device.vm.provider :libvirt do |v|
-      v.nic_model_type = 'e1000'
+      v.nic_model_type = 'e1000' 
       v.memory = 3000
     end
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
@@ -2448,7 +2448,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -2474,7 +2474,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:44:44:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:44:44:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -2490,9 +2490,9 @@ end
 
   ##### DEFINE VM for internet #####
   config.vm.define "internet" do |device|
-
-    device.vm.hostname = "internet"
-
+    
+    device.vm.hostname = "internet" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
 
@@ -2541,7 +2541,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_internet.sh"
@@ -2567,7 +2567,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:3e --> swp2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:3e", NAME="swp2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = swp48"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="swp48", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules

--- a/Vagrantfile-large-memory-vbox
+++ b/Vagrantfile-large-memory-vbox
@@ -11,7 +11,7 @@
 
 
 
-Vagrant.require_version ">= 1.8.6"
+Vagrant.require_version ">= 2.0.2"
 
 $script = <<-SCRIPT
 if grep -q -i 'cumulus' /etc/lsb-release &> /dev/null; then
@@ -50,7 +50,7 @@ if grep -q -i 'cumulus' /etc/lsb-release &> /dev/null; then
             echo "  INFO: Detected Cumulus Linux v$DISTRIB_RELEASE Release"
             if [[ $DISTRIB_RELEASE =~ ^3.[1-9].* ]]; then
                 echo "### Fixing ONIE DHCP to avoid Vagrant Interface ###"
-                echo "     Note: Installing from ONIE will undo these changes." 
+                echo "     Note: Installing from ONIE will undo these changes."
                 mkdir /tmp/foo
                 mount LABEL=ONIE-BOOT /tmp/foo
                 sed -i 's/eth0/eth1/g' /tmp/foo/grub/grub.cfg
@@ -86,9 +86,9 @@ Vagrant.configure("2") do |config|
 
   ##### DEFINE VM for oob-mgmt-server #####
   config.vm.define "oob-mgmt-server" do |device|
-    
-    device.vm.hostname = "oob-mgmt-server" 
-    
+
+    device.vm.hostname = "oob-mgmt-server"
+
     device.vm.box = "CumulusCommunity/vx_oob_server"
     device.vm.box_version = "1.0.3"
     device.vm.provider "virtualbox" do |v|
@@ -104,7 +104,7 @@ Vagrant.configure("2") do |config|
     # NETWORK INTERFACES
       # link for eth1 --> oob-mgmt-switch:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net54", auto_config: false , :mac => "443839000057"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -114,7 +114,7 @@ Vagrant.configure("2") do |config|
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_oob_server.sh"
@@ -132,7 +132,7 @@ device.vm.provision :shell , :inline => <<-udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:57 --> eth1"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:57", NAME="eth1", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = eth0"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="eth0", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -148,9 +148,9 @@ end
 
   ##### DEFINE VM for oob-mgmt-switch #####
   config.vm.define "oob-mgmt-switch" do |device|
-    
-    device.vm.hostname = "oob-mgmt-switch" 
-    
+
+    device.vm.hostname = "oob-mgmt-switch"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -166,49 +166,49 @@ end
     # NETWORK INTERFACES
       # link for swp1 --> oob-mgmt-server:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net54", auto_config: false , :mac => "a00000000061"
-      
+
       # link for swp2 --> server01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net42", auto_config: false , :mac => "443839000043"
-      
+
       # link for swp3 --> server02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net47", auto_config: false , :mac => "44383900004c"
-      
+
       # link for swp4 --> server03:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net3", auto_config: false , :mac => "443839000004"
-      
+
       # link for swp5 --> server04:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net49", auto_config: false , :mac => "44383900004e"
-      
+
       # link for swp6 --> leaf01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net20", auto_config: false , :mac => "443839000020"
-      
+
       # link for swp7 --> leaf02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net38", auto_config: false , :mac => "44383900003d"
-      
+
       # link for swp8 --> leaf03:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net28", auto_config: false , :mac => "44383900002d"
-      
+
       # link for swp9 --> leaf04:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net34", auto_config: false , :mac => "443839000037"
-      
+
       # link for swp10 --> spine01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net31", auto_config: false , :mac => "443839000032"
-      
+
       # link for swp11 --> spine02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net59", auto_config: false , :mac => "44383900005f"
-      
+
       # link for swp12 --> exit01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net9", auto_config: false , :mac => "44383900000f"
-      
+
       # link for swp13 --> exit02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net48", auto_config: false , :mac => "44383900004d"
-      
+
       # link for swp14 --> edge01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net40", auto_config: false , :mac => "443839000040"
-      
+
       # link for swp15 --> internet:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net35", auto_config: false , :mac => "443839000038"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -232,7 +232,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_oob_switch.sh"
@@ -306,7 +306,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:38 --> swp15"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:38", NAME="swp15", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = eth0"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="eth0", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -322,9 +322,9 @@ end
 
   ##### DEFINE VM for exit02 #####
   config.vm.define "exit02" do |device|
-    
-    device.vm.hostname = "exit02" 
-    
+
+    device.vm.hostname = "exit02"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -340,37 +340,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp13
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net48", auto_config: false , :mac => "a00000000042"
-      
+
       # link for swp1 --> edge01:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net7", auto_config: false , :mac => "44383900000c"
-      
+
       # link for swp44 --> internet:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net39", auto_config: false , :mac => "44383900003f"
-      
+
       # link for swp45 --> exit02:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net30", auto_config: false , :mac => "443839000030"
-      
+
       # link for swp46 --> exit02:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net30", auto_config: false , :mac => "443839000031"
-      
+
       # link for swp47 --> exit02:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net33", auto_config: false , :mac => "443839000035"
-      
+
       # link for swp48 --> exit02:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net33", auto_config: false , :mac => "443839000036"
-      
+
       # link for swp49 --> exit01:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net24", auto_config: false , :mac => "443839000027"
-      
+
       # link for swp50 --> exit01:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net14", auto_config: false , :mac => "443839000017"
-      
+
       # link for swp51 --> spine01:swp29
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net21", auto_config: false , :mac => "443839000021"
-      
+
       # link for swp52 --> spine02:swp29
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net53", auto_config: false , :mac => "443839000055"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -390,7 +390,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -448,7 +448,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:55 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:55", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -464,9 +464,9 @@ end
 
   ##### DEFINE VM for exit01 #####
   config.vm.define "exit01" do |device|
-    
-    device.vm.hostname = "exit01" 
-    
+
+    device.vm.hostname = "exit01"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -482,37 +482,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp12
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net9", auto_config: false , :mac => "a00000000041"
-      
+
       # link for swp1 --> edge01:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net46", auto_config: false , :mac => "44383900004b"
-      
+
       # link for swp44 --> internet:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net5", auto_config: false , :mac => "443839000008"
-      
+
       # link for swp45 --> exit01:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net43", auto_config: false , :mac => "443839000044"
-      
+
       # link for swp46 --> exit01:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net43", auto_config: false , :mac => "443839000045"
-      
+
       # link for swp47 --> exit01:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net11", auto_config: false , :mac => "443839000012"
-      
+
       # link for swp48 --> exit01:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net11", auto_config: false , :mac => "443839000013"
-      
+
       # link for swp49 --> exit02:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net24", auto_config: false , :mac => "443839000026"
-      
+
       # link for swp50 --> exit02:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net14", auto_config: false , :mac => "443839000016"
-      
+
       # link for swp51 --> spine01:swp30
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net6", auto_config: false , :mac => "443839000009"
-      
+
       # link for swp52 --> spine02:swp30
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net56", auto_config: false , :mac => "44383900005a"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -532,7 +532,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -590,7 +590,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:5a --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:5a", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -606,9 +606,9 @@ end
 
   ##### DEFINE VM for spine02 #####
   config.vm.define "spine02" do |device|
-    
-    device.vm.hostname = "spine02" 
-    
+
+    device.vm.hostname = "spine02"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -624,31 +624,31 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp11
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net59", auto_config: false , :mac => "a00000000022"
-      
+
       # link for swp1 --> leaf01:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net23", auto_config: false , :mac => "443839000025"
-      
+
       # link for swp2 --> leaf02:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net58", auto_config: false , :mac => "44383900005e"
-      
+
       # link for swp3 --> leaf03:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net17", auto_config: false , :mac => "44383900001c"
-      
+
       # link for swp4 --> leaf04:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net44", auto_config: false , :mac => "443839000047"
-      
+
       # link for swp29 --> exit02:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net53", auto_config: false , :mac => "443839000056"
-      
+
       # link for swp30 --> exit01:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net56", auto_config: false , :mac => "44383900005b"
-      
+
       # link for swp31 --> spine01:swp31
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net45", auto_config: false , :mac => "443839000049"
-      
+
       # link for swp32 --> spine01:swp32
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net36", auto_config: false , :mac => "44383900003a"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -666,7 +666,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -716,7 +716,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:3a --> swp32"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:3a", NAME="swp32", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -732,9 +732,9 @@ end
 
   ##### DEFINE VM for spine01 #####
   config.vm.define "spine01" do |device|
-    
-    device.vm.hostname = "spine01" 
-    
+
+    device.vm.hostname = "spine01"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -750,31 +750,31 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp10
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net31", auto_config: false , :mac => "a00000000021"
-      
+
       # link for swp1 --> leaf01:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net52", auto_config: false , :mac => "443839000054"
-      
+
       # link for swp2 --> leaf02:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net25", auto_config: false , :mac => "443839000029"
-      
+
       # link for swp3 --> leaf03:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net50", auto_config: false , :mac => "443839000050"
-      
+
       # link for swp4 --> leaf04:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net37", auto_config: false , :mac => "44383900003c"
-      
+
       # link for swp29 --> exit02:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net21", auto_config: false , :mac => "443839000022"
-      
+
       # link for swp30 --> exit01:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net6", auto_config: false , :mac => "44383900000a"
-      
+
       # link for swp31 --> spine02:swp31
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net45", auto_config: false , :mac => "443839000048"
-      
+
       # link for swp32 --> spine02:swp32
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net36", auto_config: false , :mac => "443839000039"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -792,7 +792,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -842,7 +842,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:39 --> swp32"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:39", NAME="swp32", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -858,9 +858,9 @@ end
 
   ##### DEFINE VM for leaf04 #####
   config.vm.define "leaf04" do |device|
-    
-    device.vm.hostname = "leaf04" 
-    
+
+    device.vm.hostname = "leaf04"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -876,37 +876,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp9
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net34", auto_config: false , :mac => "a00000000014"
-      
+
       # link for swp1 --> server03:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net57", auto_config: false , :mac => "44383900005c"
-      
+
       # link for swp2 --> server04:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net27", auto_config: false , :mac => "44383900002c"
-      
+
       # link for swp45 --> leaf04:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net16", auto_config: false , :mac => "443839000019"
-      
+
       # link for swp46 --> leaf04:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net16", auto_config: false , :mac => "44383900001a"
-      
+
       # link for swp47 --> leaf04:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net32", auto_config: false , :mac => "443839000033"
-      
+
       # link for swp48 --> leaf04:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net32", auto_config: false , :mac => "443839000034"
-      
+
       # link for swp49 --> leaf03:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net29", auto_config: false , :mac => "44383900002f"
-      
+
       # link for swp50 --> leaf03:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net4", auto_config: false , :mac => "443839000006"
-      
+
       # link for swp51 --> spine01:swp4
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net37", auto_config: false , :mac => "44383900003b"
-      
+
       # link for swp52 --> spine02:swp4
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net44", auto_config: false , :mac => "443839000046"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -926,7 +926,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -984,7 +984,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:46 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:46", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1000,9 +1000,9 @@ end
 
   ##### DEFINE VM for leaf02 #####
   config.vm.define "leaf02" do |device|
-    
-    device.vm.hostname = "leaf02" 
-    
+
+    device.vm.hostname = "leaf02"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1018,37 +1018,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp7
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net38", auto_config: false , :mac => "a00000000012"
-      
+
       # link for swp1 --> server01:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net13", auto_config: false , :mac => "443839000015"
-      
+
       # link for swp2 --> server02:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net15", auto_config: false , :mac => "443839000018"
-      
+
       # link for swp45 --> leaf02:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net8", auto_config: false , :mac => "44383900000d"
-      
+
       # link for swp46 --> leaf02:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net8", auto_config: false , :mac => "44383900000e"
-      
+
       # link for swp47 --> leaf02:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net55", auto_config: false , :mac => "443839000058"
-      
+
       # link for swp48 --> leaf02:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net55", auto_config: false , :mac => "443839000059"
-      
+
       # link for swp49 --> leaf01:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net10", auto_config: false , :mac => "443839000011"
-      
+
       # link for swp50 --> leaf01:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net1", auto_config: false , :mac => "443839000002"
-      
+
       # link for swp51 --> spine01:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net25", auto_config: false , :mac => "443839000028"
-      
+
       # link for swp52 --> spine02:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net58", auto_config: false , :mac => "44383900005d"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1068,7 +1068,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1126,7 +1126,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:5d --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:5d", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1142,9 +1142,9 @@ end
 
   ##### DEFINE VM for leaf03 #####
   config.vm.define "leaf03" do |device|
-    
-    device.vm.hostname = "leaf03" 
-    
+
+    device.vm.hostname = "leaf03"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1160,37 +1160,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp8
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net28", auto_config: false , :mac => "a00000000013"
-      
+
       # link for swp1 --> server03:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net22", auto_config: false , :mac => "443839000023"
-      
+
       # link for swp2 --> server04:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net19", auto_config: false , :mac => "44383900001f"
-      
+
       # link for swp45 --> leaf03:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net26", auto_config: false , :mac => "44383900002a"
-      
+
       # link for swp46 --> leaf03:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net26", auto_config: false , :mac => "44383900002b"
-      
+
       # link for swp47 --> leaf03:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net51", auto_config: false , :mac => "443839000051"
-      
+
       # link for swp48 --> leaf03:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net51", auto_config: false , :mac => "443839000052"
-      
+
       # link for swp49 --> leaf04:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net29", auto_config: false , :mac => "44383900002e"
-      
+
       # link for swp50 --> leaf04:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net4", auto_config: false , :mac => "443839000005"
-      
+
       # link for swp51 --> spine01:swp3
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net50", auto_config: false , :mac => "44383900004f"
-      
+
       # link for swp52 --> spine02:swp3
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net17", auto_config: false , :mac => "44383900001b"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1210,7 +1210,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1268,7 +1268,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:1b --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:1b", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1284,9 +1284,9 @@ end
 
   ##### DEFINE VM for leaf01 #####
   config.vm.define "leaf01" do |device|
-    
-    device.vm.hostname = "leaf01" 
-    
+
+    device.vm.hostname = "leaf01"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1302,37 +1302,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp6
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net20", auto_config: false , :mac => "a00000000011"
-      
+
       # link for swp1 --> server01:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net2", auto_config: false , :mac => "443839000003"
-      
+
       # link for swp2 --> server02:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net12", auto_config: false , :mac => "443839000014"
-      
+
       # link for swp45 --> leaf01:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net18", auto_config: false , :mac => "44383900001d"
-      
+
       # link for swp46 --> leaf01:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net18", auto_config: false , :mac => "44383900001e"
-      
+
       # link for swp47 --> leaf01:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net41", auto_config: false , :mac => "443839000041"
-      
+
       # link for swp48 --> leaf01:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net41", auto_config: false , :mac => "443839000042"
-      
+
       # link for swp49 --> leaf02:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net10", auto_config: false , :mac => "443839000010"
-      
+
       # link for swp50 --> leaf02:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net1", auto_config: false , :mac => "443839000001"
-      
+
       # link for swp51 --> spine01:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net52", auto_config: false , :mac => "443839000053"
-      
+
       # link for swp52 --> spine02:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net23", auto_config: false , :mac => "443839000024"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1352,7 +1352,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1410,7 +1410,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:24 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:24", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1426,9 +1426,9 @@ end
 
   ##### DEFINE VM for edge01 #####
   config.vm.define "edge01" do |device|
-    
-    device.vm.hostname = "edge01" 
-    
+
+    device.vm.hostname = "edge01"
+
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_edge01"
@@ -1443,13 +1443,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp14
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net40", auto_config: false , :mac => "a00000000051"
-      
+
       # link for eth1 --> exit01:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net46", auto_config: false , :mac => "44383900004a"
-      
+
       # link for eth2 --> exit02:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net7", auto_config: false , :mac => "44383900000b"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1464,7 +1464,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1490,7 +1490,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:0b --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:0b", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1506,9 +1506,9 @@ end
 
   ##### DEFINE VM for server01 #####
   config.vm.define "server01" do |device|
-    
-    device.vm.hostname = "server01" 
-    
+
+    device.vm.hostname = "server01"
+
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server01"
@@ -1523,13 +1523,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net42", auto_config: false , :mac => "a00000000031"
-      
+
       # link for eth1 --> leaf01:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net2", auto_config: false , :mac => "000300111101"
-      
+
       # link for eth2 --> leaf02:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net13", auto_config: false , :mac => "000300111102"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1544,7 +1544,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1570,7 +1570,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:11:11:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:11:11:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1586,9 +1586,9 @@ end
 
   ##### DEFINE VM for server03 #####
   config.vm.define "server03" do |device|
-    
-    device.vm.hostname = "server03" 
-    
+
+    device.vm.hostname = "server03"
+
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server03"
@@ -1603,13 +1603,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp4
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net3", auto_config: false , :mac => "a00000000033"
-      
+
       # link for eth1 --> leaf03:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net22", auto_config: false , :mac => "000300333301"
-      
+
       # link for eth2 --> leaf04:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net57", auto_config: false , :mac => "000300333302"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1624,7 +1624,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1650,7 +1650,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:33:33:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:33:33:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1666,9 +1666,9 @@ end
 
   ##### DEFINE VM for server02 #####
   config.vm.define "server02" do |device|
-    
-    device.vm.hostname = "server02" 
-    
+
+    device.vm.hostname = "server02"
+
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server02"
@@ -1683,13 +1683,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp3
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net47", auto_config: false , :mac => "a00000000032"
-      
+
       # link for eth1 --> leaf01:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net12", auto_config: false , :mac => "000300222201"
-      
+
       # link for eth2 --> leaf02:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net15", auto_config: false , :mac => "000300222202"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1704,7 +1704,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1730,7 +1730,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:22:22:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:22:22:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1746,9 +1746,9 @@ end
 
   ##### DEFINE VM for server04 #####
   config.vm.define "server04" do |device|
-    
-    device.vm.hostname = "server04" 
-    
+
+    device.vm.hostname = "server04"
+
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server04"
@@ -1763,13 +1763,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp5
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net49", auto_config: false , :mac => "a00000000034"
-      
+
       # link for eth1 --> leaf03:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net19", auto_config: false , :mac => "000300444401"
-      
+
       # link for eth2 --> leaf04:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net27", auto_config: false , :mac => "000300444402"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1784,7 +1784,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1810,7 +1810,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:44:44:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:44:44:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1826,9 +1826,9 @@ end
 
   ##### DEFINE VM for internet #####
   config.vm.define "internet" do |device|
-    
-    device.vm.hostname = "internet" 
-    
+
+    device.vm.hostname = "internet"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1844,13 +1844,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp15
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net35", auto_config: false , :mac => "a00000000050"
-      
+
       # link for swp1 --> exit01:swp44
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net5", auto_config: false , :mac => "443839000007"
-      
+
       # link for swp2 --> exit02:swp44
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net39", auto_config: false , :mac => "44383900003e"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1862,7 +1862,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_internet.sh"
@@ -1888,7 +1888,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:3e --> swp2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:3e", NAME="swp2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = swp48"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="swp48", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules

--- a/Vagrantfile-large-memory-vbox
+++ b/Vagrantfile-large-memory-vbox
@@ -5,7 +5,7 @@
 #    built with the following args: ./topology_converter.py ./topology_large_memory.dot
 #
 #    NOTE: in order to use this Vagrantfile you will need:
-#       -Vagrant(v1.8.6+) installed: http://www.vagrantup.com/downloads
+#       -Vagrant(v2.0.2+) installed: http://www.vagrantup.com/downloads
 #       -the "helper_scripts" directory that comes packaged with topology-converter.py
 #       -Virtualbox installed: https://www.virtualbox.org/wiki/Downloads
 
@@ -50,7 +50,7 @@ if grep -q -i 'cumulus' /etc/lsb-release &> /dev/null; then
             echo "  INFO: Detected Cumulus Linux v$DISTRIB_RELEASE Release"
             if [[ $DISTRIB_RELEASE =~ ^3.[1-9].* ]]; then
                 echo "### Fixing ONIE DHCP to avoid Vagrant Interface ###"
-                echo "     Note: Installing from ONIE will undo these changes."
+                echo "     Note: Installing from ONIE will undo these changes." 
                 mkdir /tmp/foo
                 mount LABEL=ONIE-BOOT /tmp/foo
                 sed -i 's/eth0/eth1/g' /tmp/foo/grub/grub.cfg
@@ -86,9 +86,9 @@ Vagrant.configure("2") do |config|
 
   ##### DEFINE VM for oob-mgmt-server #####
   config.vm.define "oob-mgmt-server" do |device|
-
-    device.vm.hostname = "oob-mgmt-server"
-
+    
+    device.vm.hostname = "oob-mgmt-server" 
+    
     device.vm.box = "CumulusCommunity/vx_oob_server"
     device.vm.box_version = "1.0.3"
     device.vm.provider "virtualbox" do |v|
@@ -104,7 +104,7 @@ Vagrant.configure("2") do |config|
     # NETWORK INTERFACES
       # link for eth1 --> oob-mgmt-switch:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net54", auto_config: false , :mac => "443839000057"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -114,7 +114,7 @@ Vagrant.configure("2") do |config|
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_oob_server.sh"
@@ -132,7 +132,7 @@ device.vm.provision :shell , :inline => <<-udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:57 --> eth1"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:57", NAME="eth1", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = eth0"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="eth0", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -148,9 +148,9 @@ end
 
   ##### DEFINE VM for oob-mgmt-switch #####
   config.vm.define "oob-mgmt-switch" do |device|
-
-    device.vm.hostname = "oob-mgmt-switch"
-
+    
+    device.vm.hostname = "oob-mgmt-switch" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -166,49 +166,49 @@ end
     # NETWORK INTERFACES
       # link for swp1 --> oob-mgmt-server:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net54", auto_config: false , :mac => "a00000000061"
-
+      
       # link for swp2 --> server01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net42", auto_config: false , :mac => "443839000043"
-
+      
       # link for swp3 --> server02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net47", auto_config: false , :mac => "44383900004c"
-
+      
       # link for swp4 --> server03:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net3", auto_config: false , :mac => "443839000004"
-
+      
       # link for swp5 --> server04:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net49", auto_config: false , :mac => "44383900004e"
-
+      
       # link for swp6 --> leaf01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net20", auto_config: false , :mac => "443839000020"
-
+      
       # link for swp7 --> leaf02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net38", auto_config: false , :mac => "44383900003d"
-
+      
       # link for swp8 --> leaf03:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net28", auto_config: false , :mac => "44383900002d"
-
+      
       # link for swp9 --> leaf04:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net34", auto_config: false , :mac => "443839000037"
-
+      
       # link for swp10 --> spine01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net31", auto_config: false , :mac => "443839000032"
-
+      
       # link for swp11 --> spine02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net59", auto_config: false , :mac => "44383900005f"
-
+      
       # link for swp12 --> exit01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net9", auto_config: false , :mac => "44383900000f"
-
+      
       # link for swp13 --> exit02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net48", auto_config: false , :mac => "44383900004d"
-
+      
       # link for swp14 --> edge01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net40", auto_config: false , :mac => "443839000040"
-
+      
       # link for swp15 --> internet:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net35", auto_config: false , :mac => "443839000038"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -232,7 +232,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_oob_switch.sh"
@@ -306,7 +306,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:38 --> swp15"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:38", NAME="swp15", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = eth0"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="eth0", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -322,9 +322,9 @@ end
 
   ##### DEFINE VM for exit02 #####
   config.vm.define "exit02" do |device|
-
-    device.vm.hostname = "exit02"
-
+    
+    device.vm.hostname = "exit02" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -340,37 +340,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp13
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net48", auto_config: false , :mac => "a00000000042"
-
+      
       # link for swp1 --> edge01:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net7", auto_config: false , :mac => "44383900000c"
-
+      
       # link for swp44 --> internet:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net39", auto_config: false , :mac => "44383900003f"
-
+      
       # link for swp45 --> exit02:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net30", auto_config: false , :mac => "443839000030"
-
+      
       # link for swp46 --> exit02:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net30", auto_config: false , :mac => "443839000031"
-
+      
       # link for swp47 --> exit02:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net33", auto_config: false , :mac => "443839000035"
-
+      
       # link for swp48 --> exit02:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net33", auto_config: false , :mac => "443839000036"
-
+      
       # link for swp49 --> exit01:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net24", auto_config: false , :mac => "443839000027"
-
+      
       # link for swp50 --> exit01:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net14", auto_config: false , :mac => "443839000017"
-
+      
       # link for swp51 --> spine01:swp29
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net21", auto_config: false , :mac => "443839000021"
-
+      
       # link for swp52 --> spine02:swp29
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net53", auto_config: false , :mac => "443839000055"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -390,7 +390,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -448,7 +448,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:55 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:55", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -464,9 +464,9 @@ end
 
   ##### DEFINE VM for exit01 #####
   config.vm.define "exit01" do |device|
-
-    device.vm.hostname = "exit01"
-
+    
+    device.vm.hostname = "exit01" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -482,37 +482,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp12
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net9", auto_config: false , :mac => "a00000000041"
-
+      
       # link for swp1 --> edge01:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net46", auto_config: false , :mac => "44383900004b"
-
+      
       # link for swp44 --> internet:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net5", auto_config: false , :mac => "443839000008"
-
+      
       # link for swp45 --> exit01:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net43", auto_config: false , :mac => "443839000044"
-
+      
       # link for swp46 --> exit01:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net43", auto_config: false , :mac => "443839000045"
-
+      
       # link for swp47 --> exit01:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net11", auto_config: false , :mac => "443839000012"
-
+      
       # link for swp48 --> exit01:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net11", auto_config: false , :mac => "443839000013"
-
+      
       # link for swp49 --> exit02:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net24", auto_config: false , :mac => "443839000026"
-
+      
       # link for swp50 --> exit02:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net14", auto_config: false , :mac => "443839000016"
-
+      
       # link for swp51 --> spine01:swp30
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net6", auto_config: false , :mac => "443839000009"
-
+      
       # link for swp52 --> spine02:swp30
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net56", auto_config: false , :mac => "44383900005a"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -532,7 +532,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -590,7 +590,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:5a --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:5a", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -606,9 +606,9 @@ end
 
   ##### DEFINE VM for spine02 #####
   config.vm.define "spine02" do |device|
-
-    device.vm.hostname = "spine02"
-
+    
+    device.vm.hostname = "spine02" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -624,31 +624,31 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp11
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net59", auto_config: false , :mac => "a00000000022"
-
+      
       # link for swp1 --> leaf01:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net23", auto_config: false , :mac => "443839000025"
-
+      
       # link for swp2 --> leaf02:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net58", auto_config: false , :mac => "44383900005e"
-
+      
       # link for swp3 --> leaf03:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net17", auto_config: false , :mac => "44383900001c"
-
+      
       # link for swp4 --> leaf04:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net44", auto_config: false , :mac => "443839000047"
-
+      
       # link for swp29 --> exit02:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net53", auto_config: false , :mac => "443839000056"
-
+      
       # link for swp30 --> exit01:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net56", auto_config: false , :mac => "44383900005b"
-
+      
       # link for swp31 --> spine01:swp31
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net45", auto_config: false , :mac => "443839000049"
-
+      
       # link for swp32 --> spine01:swp32
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net36", auto_config: false , :mac => "44383900003a"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -666,7 +666,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -716,7 +716,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:3a --> swp32"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:3a", NAME="swp32", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -732,9 +732,9 @@ end
 
   ##### DEFINE VM for spine01 #####
   config.vm.define "spine01" do |device|
-
-    device.vm.hostname = "spine01"
-
+    
+    device.vm.hostname = "spine01" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -750,31 +750,31 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp10
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net31", auto_config: false , :mac => "a00000000021"
-
+      
       # link for swp1 --> leaf01:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net52", auto_config: false , :mac => "443839000054"
-
+      
       # link for swp2 --> leaf02:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net25", auto_config: false , :mac => "443839000029"
-
+      
       # link for swp3 --> leaf03:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net50", auto_config: false , :mac => "443839000050"
-
+      
       # link for swp4 --> leaf04:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net37", auto_config: false , :mac => "44383900003c"
-
+      
       # link for swp29 --> exit02:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net21", auto_config: false , :mac => "443839000022"
-
+      
       # link for swp30 --> exit01:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net6", auto_config: false , :mac => "44383900000a"
-
+      
       # link for swp31 --> spine02:swp31
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net45", auto_config: false , :mac => "443839000048"
-
+      
       # link for swp32 --> spine02:swp32
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net36", auto_config: false , :mac => "443839000039"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -792,7 +792,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -842,7 +842,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:39 --> swp32"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:39", NAME="swp32", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -858,9 +858,9 @@ end
 
   ##### DEFINE VM for leaf04 #####
   config.vm.define "leaf04" do |device|
-
-    device.vm.hostname = "leaf04"
-
+    
+    device.vm.hostname = "leaf04" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -876,37 +876,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp9
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net34", auto_config: false , :mac => "a00000000014"
-
+      
       # link for swp1 --> server03:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net57", auto_config: false , :mac => "44383900005c"
-
+      
       # link for swp2 --> server04:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net27", auto_config: false , :mac => "44383900002c"
-
+      
       # link for swp45 --> leaf04:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net16", auto_config: false , :mac => "443839000019"
-
+      
       # link for swp46 --> leaf04:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net16", auto_config: false , :mac => "44383900001a"
-
+      
       # link for swp47 --> leaf04:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net32", auto_config: false , :mac => "443839000033"
-
+      
       # link for swp48 --> leaf04:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net32", auto_config: false , :mac => "443839000034"
-
+      
       # link for swp49 --> leaf03:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net29", auto_config: false , :mac => "44383900002f"
-
+      
       # link for swp50 --> leaf03:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net4", auto_config: false , :mac => "443839000006"
-
+      
       # link for swp51 --> spine01:swp4
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net37", auto_config: false , :mac => "44383900003b"
-
+      
       # link for swp52 --> spine02:swp4
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net44", auto_config: false , :mac => "443839000046"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -926,7 +926,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -984,7 +984,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:46 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:46", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1000,9 +1000,9 @@ end
 
   ##### DEFINE VM for leaf02 #####
   config.vm.define "leaf02" do |device|
-
-    device.vm.hostname = "leaf02"
-
+    
+    device.vm.hostname = "leaf02" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1018,37 +1018,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp7
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net38", auto_config: false , :mac => "a00000000012"
-
+      
       # link for swp1 --> server01:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net13", auto_config: false , :mac => "443839000015"
-
+      
       # link for swp2 --> server02:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net15", auto_config: false , :mac => "443839000018"
-
+      
       # link for swp45 --> leaf02:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net8", auto_config: false , :mac => "44383900000d"
-
+      
       # link for swp46 --> leaf02:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net8", auto_config: false , :mac => "44383900000e"
-
+      
       # link for swp47 --> leaf02:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net55", auto_config: false , :mac => "443839000058"
-
+      
       # link for swp48 --> leaf02:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net55", auto_config: false , :mac => "443839000059"
-
+      
       # link for swp49 --> leaf01:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net10", auto_config: false , :mac => "443839000011"
-
+      
       # link for swp50 --> leaf01:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net1", auto_config: false , :mac => "443839000002"
-
+      
       # link for swp51 --> spine01:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net25", auto_config: false , :mac => "443839000028"
-
+      
       # link for swp52 --> spine02:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net58", auto_config: false , :mac => "44383900005d"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1068,7 +1068,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1126,7 +1126,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:5d --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:5d", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1142,9 +1142,9 @@ end
 
   ##### DEFINE VM for leaf03 #####
   config.vm.define "leaf03" do |device|
-
-    device.vm.hostname = "leaf03"
-
+    
+    device.vm.hostname = "leaf03" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1160,37 +1160,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp8
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net28", auto_config: false , :mac => "a00000000013"
-
+      
       # link for swp1 --> server03:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net22", auto_config: false , :mac => "443839000023"
-
+      
       # link for swp2 --> server04:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net19", auto_config: false , :mac => "44383900001f"
-
+      
       # link for swp45 --> leaf03:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net26", auto_config: false , :mac => "44383900002a"
-
+      
       # link for swp46 --> leaf03:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net26", auto_config: false , :mac => "44383900002b"
-
+      
       # link for swp47 --> leaf03:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net51", auto_config: false , :mac => "443839000051"
-
+      
       # link for swp48 --> leaf03:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net51", auto_config: false , :mac => "443839000052"
-
+      
       # link for swp49 --> leaf04:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net29", auto_config: false , :mac => "44383900002e"
-
+      
       # link for swp50 --> leaf04:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net4", auto_config: false , :mac => "443839000005"
-
+      
       # link for swp51 --> spine01:swp3
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net50", auto_config: false , :mac => "44383900004f"
-
+      
       # link for swp52 --> spine02:swp3
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net17", auto_config: false , :mac => "44383900001b"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1210,7 +1210,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1268,7 +1268,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:1b --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:1b", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1284,9 +1284,9 @@ end
 
   ##### DEFINE VM for leaf01 #####
   config.vm.define "leaf01" do |device|
-
-    device.vm.hostname = "leaf01"
-
+    
+    device.vm.hostname = "leaf01" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1302,37 +1302,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp6
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net20", auto_config: false , :mac => "a00000000011"
-
+      
       # link for swp1 --> server01:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net2", auto_config: false , :mac => "443839000003"
-
+      
       # link for swp2 --> server02:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net12", auto_config: false , :mac => "443839000014"
-
+      
       # link for swp45 --> leaf01:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net18", auto_config: false , :mac => "44383900001d"
-
+      
       # link for swp46 --> leaf01:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net18", auto_config: false , :mac => "44383900001e"
-
+      
       # link for swp47 --> leaf01:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net41", auto_config: false , :mac => "443839000041"
-
+      
       # link for swp48 --> leaf01:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net41", auto_config: false , :mac => "443839000042"
-
+      
       # link for swp49 --> leaf02:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net10", auto_config: false , :mac => "443839000010"
-
+      
       # link for swp50 --> leaf02:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net1", auto_config: false , :mac => "443839000001"
-
+      
       # link for swp51 --> spine01:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net52", auto_config: false , :mac => "443839000053"
-
+      
       # link for swp52 --> spine02:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net23", auto_config: false , :mac => "443839000024"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1352,7 +1352,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1410,7 +1410,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:24 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:24", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1426,9 +1426,9 @@ end
 
   ##### DEFINE VM for edge01 #####
   config.vm.define "edge01" do |device|
-
-    device.vm.hostname = "edge01"
-
+    
+    device.vm.hostname = "edge01" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_edge01"
@@ -1443,13 +1443,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp14
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net40", auto_config: false , :mac => "a00000000051"
-
+      
       # link for eth1 --> exit01:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net46", auto_config: false , :mac => "44383900004a"
-
+      
       # link for eth2 --> exit02:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net7", auto_config: false , :mac => "44383900000b"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1464,7 +1464,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1490,7 +1490,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:0b --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:0b", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1506,9 +1506,9 @@ end
 
   ##### DEFINE VM for server01 #####
   config.vm.define "server01" do |device|
-
-    device.vm.hostname = "server01"
-
+    
+    device.vm.hostname = "server01" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server01"
@@ -1523,13 +1523,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net42", auto_config: false , :mac => "a00000000031"
-
+      
       # link for eth1 --> leaf01:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net2", auto_config: false , :mac => "000300111101"
-
+      
       # link for eth2 --> leaf02:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net13", auto_config: false , :mac => "000300111102"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1544,7 +1544,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1570,7 +1570,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:11:11:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:11:11:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1586,9 +1586,9 @@ end
 
   ##### DEFINE VM for server03 #####
   config.vm.define "server03" do |device|
-
-    device.vm.hostname = "server03"
-
+    
+    device.vm.hostname = "server03" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server03"
@@ -1603,13 +1603,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp4
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net3", auto_config: false , :mac => "a00000000033"
-
+      
       # link for eth1 --> leaf03:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net22", auto_config: false , :mac => "000300333301"
-
+      
       # link for eth2 --> leaf04:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net57", auto_config: false , :mac => "000300333302"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1624,7 +1624,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1650,7 +1650,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:33:33:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:33:33:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1666,9 +1666,9 @@ end
 
   ##### DEFINE VM for server02 #####
   config.vm.define "server02" do |device|
-
-    device.vm.hostname = "server02"
-
+    
+    device.vm.hostname = "server02" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server02"
@@ -1683,13 +1683,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp3
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net47", auto_config: false , :mac => "a00000000032"
-
+      
       # link for eth1 --> leaf01:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net12", auto_config: false , :mac => "000300222201"
-
+      
       # link for eth2 --> leaf02:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net15", auto_config: false , :mac => "000300222202"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1704,7 +1704,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1730,7 +1730,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:22:22:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:22:22:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1746,9 +1746,9 @@ end
 
   ##### DEFINE VM for server04 #####
   config.vm.define "server04" do |device|
-
-    device.vm.hostname = "server04"
-
+    
+    device.vm.hostname = "server04" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server04"
@@ -1763,13 +1763,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp5
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net49", auto_config: false , :mac => "a00000000034"
-
+      
       # link for eth1 --> leaf03:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net19", auto_config: false , :mac => "000300444401"
-
+      
       # link for eth2 --> leaf04:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net27", auto_config: false , :mac => "000300444402"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1784,7 +1784,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1810,7 +1810,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:44:44:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:44:44:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1826,9 +1826,9 @@ end
 
   ##### DEFINE VM for internet #####
   config.vm.define "internet" do |device|
-
-    device.vm.hostname = "internet"
-
+    
+    device.vm.hostname = "internet" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1844,13 +1844,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp15
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net35", auto_config: false , :mac => "a00000000050"
-
+      
       # link for swp1 --> exit01:swp44
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net5", auto_config: false , :mac => "443839000007"
-
+      
       # link for swp2 --> exit02:swp44
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net39", auto_config: false , :mac => "44383900003e"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1862,7 +1862,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_internet.sh"
@@ -1888,7 +1888,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:3e --> swp2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:3e", NAME="swp2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = swp48"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="swp48", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules

--- a/Vagrantfile-vbox
+++ b/Vagrantfile-vbox
@@ -11,7 +11,7 @@
 
 
 
-Vagrant.require_version ">= 1.8.6"
+Vagrant.require_version ">= 2.0.2"
 
 $script = <<-SCRIPT
 if grep -q -i 'cumulus' /etc/lsb-release &> /dev/null; then
@@ -50,7 +50,7 @@ if grep -q -i 'cumulus' /etc/lsb-release &> /dev/null; then
             echo "  INFO: Detected Cumulus Linux v$DISTRIB_RELEASE Release"
             if [[ $DISTRIB_RELEASE =~ ^3.[1-9].* ]]; then
                 echo "### Fixing ONIE DHCP to avoid Vagrant Interface ###"
-                echo "     Note: Installing from ONIE will undo these changes." 
+                echo "     Note: Installing from ONIE will undo these changes."
                 mkdir /tmp/foo
                 mount LABEL=ONIE-BOOT /tmp/foo
                 sed -i 's/eth0/eth1/g' /tmp/foo/grub/grub.cfg
@@ -86,9 +86,9 @@ Vagrant.configure("2") do |config|
 
   ##### DEFINE VM for oob-mgmt-server #####
   config.vm.define "oob-mgmt-server" do |device|
-    
-    device.vm.hostname = "oob-mgmt-server" 
-    
+
+    device.vm.hostname = "oob-mgmt-server"
+
     device.vm.box = "CumulusCommunity/vx_oob_server"
     device.vm.box_version = "1.0.4"
     device.vm.provider "virtualbox" do |v|
@@ -104,7 +104,7 @@ Vagrant.configure("2") do |config|
     # NETWORK INTERFACES
       # link for eth1 --> oob-mgmt-switch:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net54", auto_config: false , :mac => "443839000057"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -114,7 +114,7 @@ Vagrant.configure("2") do |config|
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_oob_server.sh"
@@ -132,7 +132,7 @@ device.vm.provision :shell , :inline => <<-udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:57 --> eth1"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:57", NAME="eth1", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = eth0"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="eth0", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -148,9 +148,9 @@ end
 
   ##### DEFINE VM for oob-mgmt-switch #####
   config.vm.define "oob-mgmt-switch" do |device|
-    
-    device.vm.hostname = "oob-mgmt-switch" 
-    
+
+    device.vm.hostname = "oob-mgmt-switch"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -166,49 +166,49 @@ end
     # NETWORK INTERFACES
       # link for swp1 --> oob-mgmt-server:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net54", auto_config: false , :mac => "a00000000061"
-      
+
       # link for swp2 --> server01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net42", auto_config: false , :mac => "443839000043"
-      
+
       # link for swp3 --> server02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net47", auto_config: false , :mac => "44383900004c"
-      
+
       # link for swp4 --> server03:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net3", auto_config: false , :mac => "443839000004"
-      
+
       # link for swp5 --> server04:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net49", auto_config: false , :mac => "44383900004e"
-      
+
       # link for swp6 --> leaf01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net20", auto_config: false , :mac => "443839000020"
-      
+
       # link for swp7 --> leaf02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net38", auto_config: false , :mac => "44383900003d"
-      
+
       # link for swp8 --> leaf03:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net28", auto_config: false , :mac => "44383900002d"
-      
+
       # link for swp9 --> leaf04:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net34", auto_config: false , :mac => "443839000037"
-      
+
       # link for swp10 --> spine01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net31", auto_config: false , :mac => "443839000032"
-      
+
       # link for swp11 --> spine02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net59", auto_config: false , :mac => "44383900005f"
-      
+
       # link for swp12 --> exit01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net9", auto_config: false , :mac => "44383900000f"
-      
+
       # link for swp13 --> exit02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net48", auto_config: false , :mac => "44383900004d"
-      
+
       # link for swp14 --> edge01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net40", auto_config: false , :mac => "443839000040"
-      
+
       # link for swp15 --> internet:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net35", auto_config: false , :mac => "443839000038"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -232,7 +232,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_oob_switch.sh"
@@ -306,7 +306,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:38 --> swp15"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:38", NAME="swp15", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = eth0"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="eth0", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -322,9 +322,9 @@ end
 
   ##### DEFINE VM for exit02 #####
   config.vm.define "exit02" do |device|
-    
-    device.vm.hostname = "exit02" 
-    
+
+    device.vm.hostname = "exit02"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -340,37 +340,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp13
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net48", auto_config: false , :mac => "a00000000042"
-      
+
       # link for swp1 --> edge01:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net7", auto_config: false , :mac => "44383900000c"
-      
+
       # link for swp44 --> internet:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net39", auto_config: false , :mac => "44383900003f"
-      
+
       # link for swp45 --> exit02:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net30", auto_config: false , :mac => "443839000030"
-      
+
       # link for swp46 --> exit02:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net30", auto_config: false , :mac => "443839000031"
-      
+
       # link for swp47 --> exit02:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net33", auto_config: false , :mac => "443839000035"
-      
+
       # link for swp48 --> exit02:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net33", auto_config: false , :mac => "443839000036"
-      
+
       # link for swp49 --> exit01:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net24", auto_config: false , :mac => "443839000027"
-      
+
       # link for swp50 --> exit01:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net14", auto_config: false , :mac => "443839000017"
-      
+
       # link for swp51 --> spine01:swp29
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net21", auto_config: false , :mac => "443839000021"
-      
+
       # link for swp52 --> spine02:swp29
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net53", auto_config: false , :mac => "443839000055"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -390,7 +390,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -448,7 +448,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:55 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:55", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -464,9 +464,9 @@ end
 
   ##### DEFINE VM for exit01 #####
   config.vm.define "exit01" do |device|
-    
-    device.vm.hostname = "exit01" 
-    
+
+    device.vm.hostname = "exit01"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -482,37 +482,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp12
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net9", auto_config: false , :mac => "a00000000041"
-      
+
       # link for swp1 --> edge01:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net46", auto_config: false , :mac => "44383900004b"
-      
+
       # link for swp44 --> internet:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net5", auto_config: false , :mac => "443839000008"
-      
+
       # link for swp45 --> exit01:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net43", auto_config: false , :mac => "443839000044"
-      
+
       # link for swp46 --> exit01:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net43", auto_config: false , :mac => "443839000045"
-      
+
       # link for swp47 --> exit01:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net11", auto_config: false , :mac => "443839000012"
-      
+
       # link for swp48 --> exit01:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net11", auto_config: false , :mac => "443839000013"
-      
+
       # link for swp49 --> exit02:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net24", auto_config: false , :mac => "443839000026"
-      
+
       # link for swp50 --> exit02:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net14", auto_config: false , :mac => "443839000016"
-      
+
       # link for swp51 --> spine01:swp30
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net6", auto_config: false , :mac => "443839000009"
-      
+
       # link for swp52 --> spine02:swp30
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net56", auto_config: false , :mac => "44383900005a"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -532,7 +532,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -590,7 +590,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:5a --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:5a", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -606,9 +606,9 @@ end
 
   ##### DEFINE VM for spine02 #####
   config.vm.define "spine02" do |device|
-    
-    device.vm.hostname = "spine02" 
-    
+
+    device.vm.hostname = "spine02"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -624,31 +624,31 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp11
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net59", auto_config: false , :mac => "a00000000022"
-      
+
       # link for swp1 --> leaf01:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net23", auto_config: false , :mac => "443839000025"
-      
+
       # link for swp2 --> leaf02:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net58", auto_config: false , :mac => "44383900005e"
-      
+
       # link for swp3 --> leaf03:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net17", auto_config: false , :mac => "44383900001c"
-      
+
       # link for swp4 --> leaf04:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net44", auto_config: false , :mac => "443839000047"
-      
+
       # link for swp29 --> exit02:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net53", auto_config: false , :mac => "443839000056"
-      
+
       # link for swp30 --> exit01:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net56", auto_config: false , :mac => "44383900005b"
-      
+
       # link for swp31 --> spine01:swp31
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net45", auto_config: false , :mac => "443839000049"
-      
+
       # link for swp32 --> spine01:swp32
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net36", auto_config: false , :mac => "44383900003a"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -666,7 +666,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -716,7 +716,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:3a --> swp32"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:3a", NAME="swp32", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -732,9 +732,9 @@ end
 
   ##### DEFINE VM for spine01 #####
   config.vm.define "spine01" do |device|
-    
-    device.vm.hostname = "spine01" 
-    
+
+    device.vm.hostname = "spine01"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -750,31 +750,31 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp10
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net31", auto_config: false , :mac => "a00000000021"
-      
+
       # link for swp1 --> leaf01:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net52", auto_config: false , :mac => "443839000054"
-      
+
       # link for swp2 --> leaf02:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net25", auto_config: false , :mac => "443839000029"
-      
+
       # link for swp3 --> leaf03:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net50", auto_config: false , :mac => "443839000050"
-      
+
       # link for swp4 --> leaf04:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net37", auto_config: false , :mac => "44383900003c"
-      
+
       # link for swp29 --> exit02:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net21", auto_config: false , :mac => "443839000022"
-      
+
       # link for swp30 --> exit01:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net6", auto_config: false , :mac => "44383900000a"
-      
+
       # link for swp31 --> spine02:swp31
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net45", auto_config: false , :mac => "443839000048"
-      
+
       # link for swp32 --> spine02:swp32
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net36", auto_config: false , :mac => "443839000039"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -792,7 +792,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -842,7 +842,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:39 --> swp32"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:39", NAME="swp32", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -858,9 +858,9 @@ end
 
   ##### DEFINE VM for leaf04 #####
   config.vm.define "leaf04" do |device|
-    
-    device.vm.hostname = "leaf04" 
-    
+
+    device.vm.hostname = "leaf04"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -876,37 +876,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp9
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net34", auto_config: false , :mac => "a00000000014"
-      
+
       # link for swp1 --> server03:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net57", auto_config: false , :mac => "44383900005c"
-      
+
       # link for swp2 --> server04:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net27", auto_config: false , :mac => "44383900002c"
-      
+
       # link for swp45 --> leaf04:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net16", auto_config: false , :mac => "443839000019"
-      
+
       # link for swp46 --> leaf04:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net16", auto_config: false , :mac => "44383900001a"
-      
+
       # link for swp47 --> leaf04:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net32", auto_config: false , :mac => "443839000033"
-      
+
       # link for swp48 --> leaf04:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net32", auto_config: false , :mac => "443839000034"
-      
+
       # link for swp49 --> leaf03:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net29", auto_config: false , :mac => "44383900002f"
-      
+
       # link for swp50 --> leaf03:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net4", auto_config: false , :mac => "443839000006"
-      
+
       # link for swp51 --> spine01:swp4
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net37", auto_config: false , :mac => "44383900003b"
-      
+
       # link for swp52 --> spine02:swp4
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net44", auto_config: false , :mac => "443839000046"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -926,7 +926,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -984,7 +984,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:46 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:46", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1000,9 +1000,9 @@ end
 
   ##### DEFINE VM for leaf02 #####
   config.vm.define "leaf02" do |device|
-    
-    device.vm.hostname = "leaf02" 
-    
+
+    device.vm.hostname = "leaf02"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1018,37 +1018,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp7
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net38", auto_config: false , :mac => "a00000000012"
-      
+
       # link for swp1 --> server01:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net13", auto_config: false , :mac => "443839000015"
-      
+
       # link for swp2 --> server02:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net15", auto_config: false , :mac => "443839000018"
-      
+
       # link for swp45 --> leaf02:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net8", auto_config: false , :mac => "44383900000d"
-      
+
       # link for swp46 --> leaf02:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net8", auto_config: false , :mac => "44383900000e"
-      
+
       # link for swp47 --> leaf02:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net55", auto_config: false , :mac => "443839000058"
-      
+
       # link for swp48 --> leaf02:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net55", auto_config: false , :mac => "443839000059"
-      
+
       # link for swp49 --> leaf01:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net10", auto_config: false , :mac => "443839000011"
-      
+
       # link for swp50 --> leaf01:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net1", auto_config: false , :mac => "443839000002"
-      
+
       # link for swp51 --> spine01:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net25", auto_config: false , :mac => "443839000028"
-      
+
       # link for swp52 --> spine02:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net58", auto_config: false , :mac => "44383900005d"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1068,7 +1068,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1126,7 +1126,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:5d --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:5d", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1142,9 +1142,9 @@ end
 
   ##### DEFINE VM for leaf03 #####
   config.vm.define "leaf03" do |device|
-    
-    device.vm.hostname = "leaf03" 
-    
+
+    device.vm.hostname = "leaf03"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1160,37 +1160,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp8
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net28", auto_config: false , :mac => "a00000000013"
-      
+
       # link for swp1 --> server03:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net22", auto_config: false , :mac => "443839000023"
-      
+
       # link for swp2 --> server04:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net19", auto_config: false , :mac => "44383900001f"
-      
+
       # link for swp45 --> leaf03:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net26", auto_config: false , :mac => "44383900002a"
-      
+
       # link for swp46 --> leaf03:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net26", auto_config: false , :mac => "44383900002b"
-      
+
       # link for swp47 --> leaf03:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net51", auto_config: false , :mac => "443839000051"
-      
+
       # link for swp48 --> leaf03:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net51", auto_config: false , :mac => "443839000052"
-      
+
       # link for swp49 --> leaf04:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net29", auto_config: false , :mac => "44383900002e"
-      
+
       # link for swp50 --> leaf04:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net4", auto_config: false , :mac => "443839000005"
-      
+
       # link for swp51 --> spine01:swp3
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net50", auto_config: false , :mac => "44383900004f"
-      
+
       # link for swp52 --> spine02:swp3
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net17", auto_config: false , :mac => "44383900001b"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1210,7 +1210,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1268,7 +1268,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:1b --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:1b", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1284,9 +1284,9 @@ end
 
   ##### DEFINE VM for leaf01 #####
   config.vm.define "leaf01" do |device|
-    
-    device.vm.hostname = "leaf01" 
-    
+
+    device.vm.hostname = "leaf01"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1302,37 +1302,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp6
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net20", auto_config: false , :mac => "a00000000011"
-      
+
       # link for swp1 --> server01:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net2", auto_config: false , :mac => "443839000003"
-      
+
       # link for swp2 --> server02:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net12", auto_config: false , :mac => "443839000014"
-      
+
       # link for swp45 --> leaf01:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net18", auto_config: false , :mac => "44383900001d"
-      
+
       # link for swp46 --> leaf01:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net18", auto_config: false , :mac => "44383900001e"
-      
+
       # link for swp47 --> leaf01:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net41", auto_config: false , :mac => "443839000041"
-      
+
       # link for swp48 --> leaf01:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net41", auto_config: false , :mac => "443839000042"
-      
+
       # link for swp49 --> leaf02:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net10", auto_config: false , :mac => "443839000010"
-      
+
       # link for swp50 --> leaf02:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net1", auto_config: false , :mac => "443839000001"
-      
+
       # link for swp51 --> spine01:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net52", auto_config: false , :mac => "443839000053"
-      
+
       # link for swp52 --> spine02:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net23", auto_config: false , :mac => "443839000024"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1352,7 +1352,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1410,7 +1410,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:24 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:24", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1426,9 +1426,9 @@ end
 
   ##### DEFINE VM for edge01 #####
   config.vm.define "edge01" do |device|
-    
-    device.vm.hostname = "edge01" 
-    
+
+    device.vm.hostname = "edge01"
+
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_edge01"
@@ -1443,13 +1443,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp14
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net40", auto_config: false , :mac => "a00000000051"
-      
+
       # link for eth1 --> exit01:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net46", auto_config: false , :mac => "44383900004a"
-      
+
       # link for eth2 --> exit02:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net7", auto_config: false , :mac => "44383900000b"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1464,7 +1464,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1490,7 +1490,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:0b --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:0b", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1506,9 +1506,9 @@ end
 
   ##### DEFINE VM for server01 #####
   config.vm.define "server01" do |device|
-    
-    device.vm.hostname = "server01" 
-    
+
+    device.vm.hostname = "server01"
+
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server01"
@@ -1523,13 +1523,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net42", auto_config: false , :mac => "a00000000031"
-      
+
       # link for eth1 --> leaf01:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net2", auto_config: false , :mac => "000300111101"
-      
+
       # link for eth2 --> leaf02:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net13", auto_config: false , :mac => "000300111102"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1544,7 +1544,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1570,7 +1570,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:11:11:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:11:11:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1586,9 +1586,9 @@ end
 
   ##### DEFINE VM for server03 #####
   config.vm.define "server03" do |device|
-    
-    device.vm.hostname = "server03" 
-    
+
+    device.vm.hostname = "server03"
+
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server03"
@@ -1603,13 +1603,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp4
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net3", auto_config: false , :mac => "a00000000033"
-      
+
       # link for eth1 --> leaf03:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net22", auto_config: false , :mac => "000300333301"
-      
+
       # link for eth2 --> leaf04:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net57", auto_config: false , :mac => "000300333302"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1624,7 +1624,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1650,7 +1650,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:33:33:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:33:33:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1666,9 +1666,9 @@ end
 
   ##### DEFINE VM for server02 #####
   config.vm.define "server02" do |device|
-    
-    device.vm.hostname = "server02" 
-    
+
+    device.vm.hostname = "server02"
+
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server02"
@@ -1683,13 +1683,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp3
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net47", auto_config: false , :mac => "a00000000032"
-      
+
       # link for eth1 --> leaf01:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net12", auto_config: false , :mac => "000300222201"
-      
+
       # link for eth2 --> leaf02:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net15", auto_config: false , :mac => "000300222202"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1704,7 +1704,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1730,7 +1730,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:22:22:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:22:22:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1746,9 +1746,9 @@ end
 
   ##### DEFINE VM for server04 #####
   config.vm.define "server04" do |device|
-    
-    device.vm.hostname = "server04" 
-    
+
+    device.vm.hostname = "server04"
+
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server04"
@@ -1763,13 +1763,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp5
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net49", auto_config: false , :mac => "a00000000034"
-      
+
       # link for eth1 --> leaf03:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net19", auto_config: false , :mac => "000300444401"
-      
+
       # link for eth2 --> leaf04:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net27", auto_config: false , :mac => "000300444402"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1784,7 +1784,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1810,7 +1810,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:44:44:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:44:44:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1826,9 +1826,9 @@ end
 
   ##### DEFINE VM for internet #####
   config.vm.define "internet" do |device|
-    
-    device.vm.hostname = "internet" 
-    
+
+    device.vm.hostname = "internet"
+
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1844,13 +1844,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp15
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net35", auto_config: false , :mac => "a00000000050"
-      
+
       # link for swp1 --> exit01:swp44
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net5", auto_config: false , :mac => "443839000007"
-      
+
       # link for swp2 --> exit02:swp44
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net39", auto_config: false , :mac => "44383900003e"
-      
+
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1862,7 +1862,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-    
+
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_internet.sh"
@@ -1888,7 +1888,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:3e --> swp2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:3e", NAME="swp2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-     
+
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = swp48"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="swp48", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules

--- a/Vagrantfile-vbox
+++ b/Vagrantfile-vbox
@@ -5,7 +5,7 @@
 #    built with the following args: ./topology_converter.py ./topology.dot
 #
 #    NOTE: in order to use this Vagrantfile you will need:
-#       -Vagrant(v1.8.6+) installed: http://www.vagrantup.com/downloads
+#       -Vagrant(v2.0.2+) installed: http://www.vagrantup.com/downloads
 #       -the "helper_scripts" directory that comes packaged with topology-converter.py
 #       -Virtualbox installed: https://www.virtualbox.org/wiki/Downloads
 
@@ -50,7 +50,7 @@ if grep -q -i 'cumulus' /etc/lsb-release &> /dev/null; then
             echo "  INFO: Detected Cumulus Linux v$DISTRIB_RELEASE Release"
             if [[ $DISTRIB_RELEASE =~ ^3.[1-9].* ]]; then
                 echo "### Fixing ONIE DHCP to avoid Vagrant Interface ###"
-                echo "     Note: Installing from ONIE will undo these changes."
+                echo "     Note: Installing from ONIE will undo these changes." 
                 mkdir /tmp/foo
                 mount LABEL=ONIE-BOOT /tmp/foo
                 sed -i 's/eth0/eth1/g' /tmp/foo/grub/grub.cfg
@@ -86,9 +86,9 @@ Vagrant.configure("2") do |config|
 
   ##### DEFINE VM for oob-mgmt-server #####
   config.vm.define "oob-mgmt-server" do |device|
-
-    device.vm.hostname = "oob-mgmt-server"
-
+    
+    device.vm.hostname = "oob-mgmt-server" 
+    
     device.vm.box = "CumulusCommunity/vx_oob_server"
     device.vm.box_version = "1.0.4"
     device.vm.provider "virtualbox" do |v|
@@ -104,7 +104,7 @@ Vagrant.configure("2") do |config|
     # NETWORK INTERFACES
       # link for eth1 --> oob-mgmt-switch:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net54", auto_config: false , :mac => "443839000057"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -114,7 +114,7 @@ Vagrant.configure("2") do |config|
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_oob_server.sh"
@@ -132,7 +132,7 @@ device.vm.provision :shell , :inline => <<-udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:57 --> eth1"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:57", NAME="eth1", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = eth0"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="eth0", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -148,9 +148,9 @@ end
 
   ##### DEFINE VM for oob-mgmt-switch #####
   config.vm.define "oob-mgmt-switch" do |device|
-
-    device.vm.hostname = "oob-mgmt-switch"
-
+    
+    device.vm.hostname = "oob-mgmt-switch" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -166,49 +166,49 @@ end
     # NETWORK INTERFACES
       # link for swp1 --> oob-mgmt-server:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net54", auto_config: false , :mac => "a00000000061"
-
+      
       # link for swp2 --> server01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net42", auto_config: false , :mac => "443839000043"
-
+      
       # link for swp3 --> server02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net47", auto_config: false , :mac => "44383900004c"
-
+      
       # link for swp4 --> server03:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net3", auto_config: false , :mac => "443839000004"
-
+      
       # link for swp5 --> server04:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net49", auto_config: false , :mac => "44383900004e"
-
+      
       # link for swp6 --> leaf01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net20", auto_config: false , :mac => "443839000020"
-
+      
       # link for swp7 --> leaf02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net38", auto_config: false , :mac => "44383900003d"
-
+      
       # link for swp8 --> leaf03:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net28", auto_config: false , :mac => "44383900002d"
-
+      
       # link for swp9 --> leaf04:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net34", auto_config: false , :mac => "443839000037"
-
+      
       # link for swp10 --> spine01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net31", auto_config: false , :mac => "443839000032"
-
+      
       # link for swp11 --> spine02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net59", auto_config: false , :mac => "44383900005f"
-
+      
       # link for swp12 --> exit01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net9", auto_config: false , :mac => "44383900000f"
-
+      
       # link for swp13 --> exit02:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net48", auto_config: false , :mac => "44383900004d"
-
+      
       # link for swp14 --> edge01:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net40", auto_config: false , :mac => "443839000040"
-
+      
       # link for swp15 --> internet:eth0
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net35", auto_config: false , :mac => "443839000038"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -232,7 +232,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_oob_switch.sh"
@@ -306,7 +306,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:38 --> swp15"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:38", NAME="swp15", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = eth0"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="eth0", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -322,9 +322,9 @@ end
 
   ##### DEFINE VM for exit02 #####
   config.vm.define "exit02" do |device|
-
-    device.vm.hostname = "exit02"
-
+    
+    device.vm.hostname = "exit02" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -340,37 +340,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp13
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net48", auto_config: false , :mac => "a00000000042"
-
+      
       # link for swp1 --> edge01:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net7", auto_config: false , :mac => "44383900000c"
-
+      
       # link for swp44 --> internet:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net39", auto_config: false , :mac => "44383900003f"
-
+      
       # link for swp45 --> exit02:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net30", auto_config: false , :mac => "443839000030"
-
+      
       # link for swp46 --> exit02:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net30", auto_config: false , :mac => "443839000031"
-
+      
       # link for swp47 --> exit02:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net33", auto_config: false , :mac => "443839000035"
-
+      
       # link for swp48 --> exit02:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net33", auto_config: false , :mac => "443839000036"
-
+      
       # link for swp49 --> exit01:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net24", auto_config: false , :mac => "443839000027"
-
+      
       # link for swp50 --> exit01:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net14", auto_config: false , :mac => "443839000017"
-
+      
       # link for swp51 --> spine01:swp29
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net21", auto_config: false , :mac => "443839000021"
-
+      
       # link for swp52 --> spine02:swp29
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net53", auto_config: false , :mac => "443839000055"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -390,7 +390,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -448,7 +448,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:55 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:55", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -464,9 +464,9 @@ end
 
   ##### DEFINE VM for exit01 #####
   config.vm.define "exit01" do |device|
-
-    device.vm.hostname = "exit01"
-
+    
+    device.vm.hostname = "exit01" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -482,37 +482,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp12
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net9", auto_config: false , :mac => "a00000000041"
-
+      
       # link for swp1 --> edge01:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net46", auto_config: false , :mac => "44383900004b"
-
+      
       # link for swp44 --> internet:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net5", auto_config: false , :mac => "443839000008"
-
+      
       # link for swp45 --> exit01:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net43", auto_config: false , :mac => "443839000044"
-
+      
       # link for swp46 --> exit01:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net43", auto_config: false , :mac => "443839000045"
-
+      
       # link for swp47 --> exit01:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net11", auto_config: false , :mac => "443839000012"
-
+      
       # link for swp48 --> exit01:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net11", auto_config: false , :mac => "443839000013"
-
+      
       # link for swp49 --> exit02:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net24", auto_config: false , :mac => "443839000026"
-
+      
       # link for swp50 --> exit02:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net14", auto_config: false , :mac => "443839000016"
-
+      
       # link for swp51 --> spine01:swp30
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net6", auto_config: false , :mac => "443839000009"
-
+      
       # link for swp52 --> spine02:swp30
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net56", auto_config: false , :mac => "44383900005a"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -532,7 +532,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -590,7 +590,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:5a --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:5a", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -606,9 +606,9 @@ end
 
   ##### DEFINE VM for spine02 #####
   config.vm.define "spine02" do |device|
-
-    device.vm.hostname = "spine02"
-
+    
+    device.vm.hostname = "spine02" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -624,31 +624,31 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp11
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net59", auto_config: false , :mac => "a00000000022"
-
+      
       # link for swp1 --> leaf01:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net23", auto_config: false , :mac => "443839000025"
-
+      
       # link for swp2 --> leaf02:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net58", auto_config: false , :mac => "44383900005e"
-
+      
       # link for swp3 --> leaf03:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net17", auto_config: false , :mac => "44383900001c"
-
+      
       # link for swp4 --> leaf04:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net44", auto_config: false , :mac => "443839000047"
-
+      
       # link for swp29 --> exit02:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net53", auto_config: false , :mac => "443839000056"
-
+      
       # link for swp30 --> exit01:swp52
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net56", auto_config: false , :mac => "44383900005b"
-
+      
       # link for swp31 --> spine01:swp31
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net45", auto_config: false , :mac => "443839000049"
-
+      
       # link for swp32 --> spine01:swp32
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net36", auto_config: false , :mac => "44383900003a"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -666,7 +666,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -716,7 +716,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:3a --> swp32"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:3a", NAME="swp32", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -732,9 +732,9 @@ end
 
   ##### DEFINE VM for spine01 #####
   config.vm.define "spine01" do |device|
-
-    device.vm.hostname = "spine01"
-
+    
+    device.vm.hostname = "spine01" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -750,31 +750,31 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp10
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net31", auto_config: false , :mac => "a00000000021"
-
+      
       # link for swp1 --> leaf01:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net52", auto_config: false , :mac => "443839000054"
-
+      
       # link for swp2 --> leaf02:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net25", auto_config: false , :mac => "443839000029"
-
+      
       # link for swp3 --> leaf03:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net50", auto_config: false , :mac => "443839000050"
-
+      
       # link for swp4 --> leaf04:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net37", auto_config: false , :mac => "44383900003c"
-
+      
       # link for swp29 --> exit02:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net21", auto_config: false , :mac => "443839000022"
-
+      
       # link for swp30 --> exit01:swp51
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net6", auto_config: false , :mac => "44383900000a"
-
+      
       # link for swp31 --> spine02:swp31
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net45", auto_config: false , :mac => "443839000048"
-
+      
       # link for swp32 --> spine02:swp32
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net36", auto_config: false , :mac => "443839000039"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -792,7 +792,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -842,7 +842,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:39 --> swp32"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:39", NAME="swp32", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -858,9 +858,9 @@ end
 
   ##### DEFINE VM for leaf04 #####
   config.vm.define "leaf04" do |device|
-
-    device.vm.hostname = "leaf04"
-
+    
+    device.vm.hostname = "leaf04" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -876,37 +876,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp9
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net34", auto_config: false , :mac => "a00000000014"
-
+      
       # link for swp1 --> server03:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net57", auto_config: false , :mac => "44383900005c"
-
+      
       # link for swp2 --> server04:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net27", auto_config: false , :mac => "44383900002c"
-
+      
       # link for swp45 --> leaf04:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net16", auto_config: false , :mac => "443839000019"
-
+      
       # link for swp46 --> leaf04:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net16", auto_config: false , :mac => "44383900001a"
-
+      
       # link for swp47 --> leaf04:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net32", auto_config: false , :mac => "443839000033"
-
+      
       # link for swp48 --> leaf04:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net32", auto_config: false , :mac => "443839000034"
-
+      
       # link for swp49 --> leaf03:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net29", auto_config: false , :mac => "44383900002f"
-
+      
       # link for swp50 --> leaf03:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net4", auto_config: false , :mac => "443839000006"
-
+      
       # link for swp51 --> spine01:swp4
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net37", auto_config: false , :mac => "44383900003b"
-
+      
       # link for swp52 --> spine02:swp4
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net44", auto_config: false , :mac => "443839000046"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -926,7 +926,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -984,7 +984,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:46 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:46", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1000,9 +1000,9 @@ end
 
   ##### DEFINE VM for leaf02 #####
   config.vm.define "leaf02" do |device|
-
-    device.vm.hostname = "leaf02"
-
+    
+    device.vm.hostname = "leaf02" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1018,37 +1018,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp7
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net38", auto_config: false , :mac => "a00000000012"
-
+      
       # link for swp1 --> server01:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net13", auto_config: false , :mac => "443839000015"
-
+      
       # link for swp2 --> server02:eth2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net15", auto_config: false , :mac => "443839000018"
-
+      
       # link for swp45 --> leaf02:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net8", auto_config: false , :mac => "44383900000d"
-
+      
       # link for swp46 --> leaf02:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net8", auto_config: false , :mac => "44383900000e"
-
+      
       # link for swp47 --> leaf02:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net55", auto_config: false , :mac => "443839000058"
-
+      
       # link for swp48 --> leaf02:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net55", auto_config: false , :mac => "443839000059"
-
+      
       # link for swp49 --> leaf01:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net10", auto_config: false , :mac => "443839000011"
-
+      
       # link for swp50 --> leaf01:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net1", auto_config: false , :mac => "443839000002"
-
+      
       # link for swp51 --> spine01:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net25", auto_config: false , :mac => "443839000028"
-
+      
       # link for swp52 --> spine02:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net58", auto_config: false , :mac => "44383900005d"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1068,7 +1068,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1126,7 +1126,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:5d --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:5d", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1142,9 +1142,9 @@ end
 
   ##### DEFINE VM for leaf03 #####
   config.vm.define "leaf03" do |device|
-
-    device.vm.hostname = "leaf03"
-
+    
+    device.vm.hostname = "leaf03" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1160,37 +1160,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp8
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net28", auto_config: false , :mac => "a00000000013"
-
+      
       # link for swp1 --> server03:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net22", auto_config: false , :mac => "443839000023"
-
+      
       # link for swp2 --> server04:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net19", auto_config: false , :mac => "44383900001f"
-
+      
       # link for swp45 --> leaf03:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net26", auto_config: false , :mac => "44383900002a"
-
+      
       # link for swp46 --> leaf03:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net26", auto_config: false , :mac => "44383900002b"
-
+      
       # link for swp47 --> leaf03:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net51", auto_config: false , :mac => "443839000051"
-
+      
       # link for swp48 --> leaf03:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net51", auto_config: false , :mac => "443839000052"
-
+      
       # link for swp49 --> leaf04:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net29", auto_config: false , :mac => "44383900002e"
-
+      
       # link for swp50 --> leaf04:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net4", auto_config: false , :mac => "443839000005"
-
+      
       # link for swp51 --> spine01:swp3
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net50", auto_config: false , :mac => "44383900004f"
-
+      
       # link for swp52 --> spine02:swp3
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net17", auto_config: false , :mac => "44383900001b"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1210,7 +1210,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1268,7 +1268,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:1b --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:1b", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1284,9 +1284,9 @@ end
 
   ##### DEFINE VM for leaf01 #####
   config.vm.define "leaf01" do |device|
-
-    device.vm.hostname = "leaf01"
-
+    
+    device.vm.hostname = "leaf01" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1302,37 +1302,37 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp6
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net20", auto_config: false , :mac => "a00000000011"
-
+      
       # link for swp1 --> server01:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net2", auto_config: false , :mac => "443839000003"
-
+      
       # link for swp2 --> server02:eth1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net12", auto_config: false , :mac => "443839000014"
-
+      
       # link for swp45 --> leaf01:swp46
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net18", auto_config: false , :mac => "44383900001d"
-
+      
       # link for swp46 --> leaf01:swp45
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net18", auto_config: false , :mac => "44383900001e"
-
+      
       # link for swp47 --> leaf01:swp48
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net41", auto_config: false , :mac => "443839000041"
-
+      
       # link for swp48 --> leaf01:swp47
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net41", auto_config: false , :mac => "443839000042"
-
+      
       # link for swp49 --> leaf02:swp49
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net10", auto_config: false , :mac => "443839000010"
-
+      
       # link for swp50 --> leaf02:swp50
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net1", auto_config: false , :mac => "443839000001"
-
+      
       # link for swp51 --> spine01:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net52", auto_config: false , :mac => "443839000053"
-
+      
       # link for swp52 --> spine02:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net23", auto_config: false , :mac => "443839000024"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1352,7 +1352,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_switch.sh"
@@ -1410,7 +1410,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:24 --> swp52"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:24", NAME="swp52", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1426,9 +1426,9 @@ end
 
   ##### DEFINE VM for edge01 #####
   config.vm.define "edge01" do |device|
-
-    device.vm.hostname = "edge01"
-
+    
+    device.vm.hostname = "edge01" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_edge01"
@@ -1443,13 +1443,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp14
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net40", auto_config: false , :mac => "a00000000051"
-
+      
       # link for eth1 --> exit01:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net46", auto_config: false , :mac => "44383900004a"
-
+      
       # link for eth2 --> exit02:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net7", auto_config: false , :mac => "44383900000b"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1464,7 +1464,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1490,7 +1490,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:0b --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:0b", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1506,9 +1506,9 @@ end
 
   ##### DEFINE VM for server01 #####
   config.vm.define "server01" do |device|
-
-    device.vm.hostname = "server01"
-
+    
+    device.vm.hostname = "server01" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server01"
@@ -1523,13 +1523,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net42", auto_config: false , :mac => "a00000000031"
-
+      
       # link for eth1 --> leaf01:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net2", auto_config: false , :mac => "000300111101"
-
+      
       # link for eth2 --> leaf02:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net13", auto_config: false , :mac => "000300111102"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1544,7 +1544,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1570,7 +1570,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:11:11:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:11:11:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1586,9 +1586,9 @@ end
 
   ##### DEFINE VM for server03 #####
   config.vm.define "server03" do |device|
-
-    device.vm.hostname = "server03"
-
+    
+    device.vm.hostname = "server03" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server03"
@@ -1603,13 +1603,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp4
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net3", auto_config: false , :mac => "a00000000033"
-
+      
       # link for eth1 --> leaf03:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net22", auto_config: false , :mac => "000300333301"
-
+      
       # link for eth2 --> leaf04:swp1
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net57", auto_config: false , :mac => "000300333302"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1624,7 +1624,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1650,7 +1650,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:33:33:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:33:33:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1666,9 +1666,9 @@ end
 
   ##### DEFINE VM for server02 #####
   config.vm.define "server02" do |device|
-
-    device.vm.hostname = "server02"
-
+    
+    device.vm.hostname = "server02" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server02"
@@ -1683,13 +1683,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp3
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net47", auto_config: false , :mac => "a00000000032"
-
+      
       # link for eth1 --> leaf01:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net12", auto_config: false , :mac => "000300222201"
-
+      
       # link for eth2 --> leaf02:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net15", auto_config: false , :mac => "000300222202"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1704,7 +1704,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1730,7 +1730,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:22:22:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:22:22:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1746,9 +1746,9 @@ end
 
   ##### DEFINE VM for server04 #####
   config.vm.define "server04" do |device|
-
-    device.vm.hostname = "server04"
-
+    
+    device.vm.hostname = "server04" 
+    
     device.vm.box = "yk0/ubuntu-xenial"
     device.vm.provider "virtualbox" do |v|
       v.name = "#{simid}_server04"
@@ -1763,13 +1763,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp5
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net49", auto_config: false , :mac => "a00000000034"
-
+      
       # link for eth1 --> leaf03:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net19", auto_config: false , :mac => "000300444401"
-
+      
       # link for eth2 --> leaf04:swp2
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net27", auto_config: false , :mac => "000300444402"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1784,7 +1784,7 @@ end
     # Shorten Boot Process - Applies to Ubuntu Only - remove \"Wait for Network\"
     device.vm.provision :shell , inline: "sed -i 's/sleep [0-9]*/sleep 1/' /etc/init/failsafe.conf 2>/dev/null || true"
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_server.sh"
@@ -1810,7 +1810,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 00:03:00:44:44:02 --> eth2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="00:03:00:44:44:02", NAME="eth2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = vagrant"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="vagrant", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
@@ -1826,9 +1826,9 @@ end
 
   ##### DEFINE VM for internet #####
   config.vm.define "internet" do |device|
-
-    device.vm.hostname = "internet"
-
+    
+    device.vm.hostname = "internet" 
+    
     device.vm.box = "CumulusCommunity/cumulus-vx"
     device.vm.box_version = "3.5.1"
     device.vm.provider "virtualbox" do |v|
@@ -1844,13 +1844,13 @@ end
     # NETWORK INTERFACES
       # link for eth0 --> oob-mgmt-switch:swp15
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net35", auto_config: false , :mac => "a00000000050"
-
+      
       # link for swp1 --> exit01:swp44
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net5", auto_config: false , :mac => "443839000007"
-
+      
       # link for swp2 --> exit02:swp44
       device.vm.network "private_network", virtualbox__intnet: "#{simid}_net39", auto_config: false , :mac => "44383900003e"
-
+      
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -1862,7 +1862,7 @@ end
     # Fixes "stdin: is not a tty" and "mesg: ttyname failed : Inappropriate ioctl for device"  messages --> https://github.com/mitchellh/vagrant/issues/1673
     device.vm.provision :shell , inline: "(sudo grep -q 'mesg n' /root/.profile 2>/dev/null && sudo sed -i '/mesg n/d' /root/.profile  2>/dev/null) || true;", privileged: false
 
-
+    
     # Run the Config specified in the Node Attributes
     device.vm.provision :shell , privileged: false, :inline => 'echo "$(whoami)" > /tmp/normal_user'
     device.vm.provision :shell , path: "./helper_scripts/config_internet.sh"
@@ -1888,7 +1888,7 @@ udev_rule
 echo "  INFO: Adding UDEV Rule: 44:38:39:00:00:3e --> swp2"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{address}=="44:38:39:00:00:3e", NAME="swp2", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules
 udev_rule
-
+     
       device.vm.provision :shell , :inline => <<-vagrant_interface_rule
 echo "  INFO: Adding UDEV Rule: Vagrant interface = swp48"
 echo 'ACTION=="add", SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="swp48", SUBSYSTEMS=="pci"' >> /etc/udev/rules.d/70-persistent-net.rules

--- a/documentation/linux/README.md
+++ b/documentation/linux/README.md
@@ -23,7 +23,7 @@ This article is intended to show how to setup a simulation environment on a Linu
 ## Tools used
 
 - VirtualBox [-Version 5.1.22 Installer-](http://download.virtualbox.org/virtualbox/5.1.22/virtualbox-5.1_5.1.22-115126~Ubuntu~xenial_amd64.deb)  or [(Alternate version downloads)](https://www.virtualbox.org/wiki/Downloads)
-- Git
+- Git 
 - Vagrant [-Version 2.0.2 Installer-](https://releases.hashicorp.com/vagrant/2.0.2/vagrant_2.0.2_x86_64.deb) or [(Alternate version downloads)](https://releases.hashicorp.com/vagrant/)
 
 
@@ -67,7 +67,7 @@ Since this is the first time you bring up the VM the download may take a few min
 You should see that the 'oob-mgmt-server' VM is now in the 'running' state.
 
  7. Now let's bring up the oob-mgmt-switch with `vagrant up oob-mgmt-switch`
-
+ 
 This step is very similar to step 5 in that Vagrant detects that the Cumulus VX image is not installed locally so it fetches the VM and installs it.
 
  8. Finally once the oob-mgmt-switch has completed let's bring up some more nodes in the network: `vagrant up server01 leaf01 leaf02 spine01 spine02`
@@ -87,6 +87,6 @@ Now that we've deployed the VMs we can get to the actual networking fun.  For th
 ## Using Libvirt
 If you'd like to make use of the libvirt/kvm hypervisor that will also work.
 **Make sure to use the proper Vagrantfiles by running the following command**
-`cp ./Vagrantfile-kvm ./Vagrantfile`
+`cp ./Vagrantfile-kvm ./Vagrantfile` 
 Specific instructions for setting up your environment for simulation using the
 Libvirt/KVM hypervisor can be [found in this community article](https://getsatisfaction.cumulusnetworks.com/cumulus/topics/setting-up-an-ubuntu-16-04-server-for-simulation-with-libvirt-kvm).

--- a/documentation/linux/README.md
+++ b/documentation/linux/README.md
@@ -23,8 +23,8 @@ This article is intended to show how to setup a simulation environment on a Linu
 ## Tools used
 
 - VirtualBox [-Version 5.1.22 Installer-](http://download.virtualbox.org/virtualbox/5.1.22/virtualbox-5.1_5.1.22-115126~Ubuntu~xenial_amd64.deb)  or [(Alternate version downloads)](https://www.virtualbox.org/wiki/Downloads)
-- Git 
-- Vagrant [-Version 1.9.5 Installer-](https://releases.hashicorp.com/vagrant/1.9.5/vagrant_1.9.5_x86_64.deb) or [(Alternate version downloads)](https://releases.hashicorp.com/vagrant/)
+- Git
+- Vagrant [-Version 2.0.2 Installer-](https://releases.hashicorp.com/vagrant/2.0.2/vagrant_2.0.2_x86_64.deb) or [(Alternate version downloads)](https://releases.hashicorp.com/vagrant/)
 
 
 ## Install the tools
@@ -40,8 +40,8 @@ sudo dpkg -i ./virtualbox_5.1.22.deb
 ### Installing Vagrant
 
 ```
-wget -O vagrant_1.9.5.deb https://releases.hashicorp.com/vagrant/1.9.5/vagrant_1.9.5_x86_64.deb
-sudo dpkg -i ./vagrant_1.9.5.deb
+wget -O vagrant_2.0.2.deb https://releases.hashicorp.com/vagrant/2.0.2/vagrant_2.0.2_x86_64.deb
+sudo dpkg -i ./vagrant_2.0.2.deb
 ```
 
 ### Installing Git
@@ -67,7 +67,7 @@ Since this is the first time you bring up the VM the download may take a few min
 You should see that the 'oob-mgmt-server' VM is now in the 'running' state.
 
  7. Now let's bring up the oob-mgmt-switch with `vagrant up oob-mgmt-switch`
- 
+
 This step is very similar to step 5 in that Vagrant detects that the Cumulus VX image is not installed locally so it fetches the VM and installs it.
 
  8. Finally once the oob-mgmt-switch has completed let's bring up some more nodes in the network: `vagrant up server01 leaf01 leaf02 spine01 spine02`
@@ -87,6 +87,6 @@ Now that we've deployed the VMs we can get to the actual networking fun.  For th
 ## Using Libvirt
 If you'd like to make use of the libvirt/kvm hypervisor that will also work.
 **Make sure to use the proper Vagrantfiles by running the following command**
-`cp ./Vagrantfile-kvm ./Vagrantfile` 
+`cp ./Vagrantfile-kvm ./Vagrantfile`
 Specific instructions for setting up your environment for simulation using the
 Libvirt/KVM hypervisor can be [found in this community article](https://getsatisfaction.cumulusnetworks.com/cumulus/topics/setting-up-an-ubuntu-16-04-server-for-simulation-with-libvirt-kvm).

--- a/documentation/windows/README.md
+++ b/documentation/windows/README.md
@@ -62,15 +62,15 @@ VirtualBox should now be installed on the server and you can create/delete VMs o
 The git install includes the Git application but also installs a bash shell built on MINGW64 (Simiar to Cygwin) to provide Linux utilities on Windows.  It's a pretty great bash environment for Windows if you haven't used it before give it a try.  This guide however will concentrate on Windows deployments as such Powershell will be the primary method of interacting with Vagrant/Virtualbox.
 
  1. After downloading Git launch the installer.
-
+ 
 ![git_step1](./screenshots/git01.png?raw=true)
-
+ 
  2. Choose the install options in this guide we will enable large file support I also enable the associations for *.git and *.sh
-
+ 
 ![git_step2](./screenshots/git02.png?raw=true)
 
  3. Add Git to the windows PATH so that it's usable from both bash and Powershell.
-
+ 
 ![git_step3](./screenshots/git03.png?raw=true)
 
  4. Choose where to authenticate SSL certs when connecting to a Git repository.  If your company has an internal Stash, GitLab, or GitHub instance you might want to use your company's MS CA setup.  For this guide we are connected to public GitHub instances so the bundled certs and public authentication in OpenSSL work just fine.  If you're not sure choose the OpenSSL method, you can always change it later.
@@ -97,9 +97,9 @@ The git install includes the Git application but also installs a bash shell buil
 ### Installing Vagrant
 
 Vagrant is the final tool that will orchestrate all the VM creation and networking.  This install will require a reboot for both Server and Desktop versions of Windows.
+ 
 
-
- 1. Install Vagrant from the msi installer.
+ 1. Install Vagrant from the msi installer.  
 
 ![git_step1](./screenshots/vagrant01.png?raw=true)
 
@@ -152,10 +152,10 @@ Since this is the first time you bring up the VM the download may take a few min
 ![git_step6](./screenshots/ps06.png?raw=true)
 
  7a. Install the Cumulus Vx image with `vagrant box add CumulusCommunity/cumulus-vx --insecure --box-version=3.3.2 --provider virtualbox`
-
+ 
  7b. Now bring up the oob-mgmt-switch with `vagrant up oob-mgmt-switch`
 
-This step is very similar to step 5a in that Vagrant detects that the Cumulus VX image is not installed locally so it fetches the VM and installs it.
+This step is very similar to step 5a in that Vagrant detects that the Cumulus VX image is not installed locally so it fetches the VM and installs it. 
 
  8. Finally once the oob-mgmt-switch has completed let's bring up some more nodes in the network: `vagrant up server01 leaf01 leaf02 spine01 spine02`
 
@@ -177,7 +177,7 @@ Now that we've deployed the VMs we can get to the actual networking fun.  For th
 ![git_step2](./screenshots/vbox_gui02.png?raw=true)
 
  3. You'll be connected to the console and it will ask about mouse capture.  The release key sequence is right control.  You will then be dropped onto the console of the oob-mgmt-server
-
+  
 ![git_step3](./screenshots/vbox_gui03.png?raw=true)
 
  4. The default login for the oob-mgmt-server is username: cumulus password: CumulusLinux!
@@ -193,7 +193,7 @@ Now that we've deployed the VMs we can get to the actual networking fun.  For th
  1. Vagrant spins up each VM with a port forward for SSH for each VM you bring up.  To find the port number that has been created use `vagrant port oob-mgmt-server`
 
 ![git_step1](./screenshots/putty01.png?raw=true)
-
+ 
  2. Launch putty and connect to the oob-mgmt-server 127.0.0.1:2222
 
 ![git_step2](./screenshots/putty02.png?raw=true)

--- a/documentation/windows/README.md
+++ b/documentation/windows/README.md
@@ -27,7 +27,7 @@ This article is intended to show how to setup a simulation environment on a Wind
 
 - VirtualBox [-Version 5.1.18 Installer-](http://download.virtualbox.org/virtualbox/5.1.18/VirtualBox-5.1.18-114002-Win.exe)  or [(Alternate version downloads)](https://www.virtualbox.org/wiki/Downloads)
 - Git [-Version 2.12.2.2 Installer-](https://github.com/git-for-windows/git/releases/download/v2.12.2.windows.2/Git-2.12.2.2-64-bit.exe)
-- Vagrant [-Version 1.9.3 Installer-](https://releases.hashicorp.com/vagrant/1.9.3/vagrant_1.9.3.msi) or [(Alternate version downloads)](https://releases.hashicorp.com/vagrant/)
+- Vagrant [-Version 2.0.2 Installer-](https://releases.hashicorp.com/vagrant/2.0.2/vagrant_2.0.2_x86_64.msi) or [(Alternate version downloads)](https://releases.hashicorp.com/vagrant/)
 
 
 
@@ -62,15 +62,15 @@ VirtualBox should now be installed on the server and you can create/delete VMs o
 The git install includes the Git application but also installs a bash shell built on MINGW64 (Simiar to Cygwin) to provide Linux utilities on Windows.  It's a pretty great bash environment for Windows if you haven't used it before give it a try.  This guide however will concentrate on Windows deployments as such Powershell will be the primary method of interacting with Vagrant/Virtualbox.
 
  1. After downloading Git launch the installer.
- 
+
 ![git_step1](./screenshots/git01.png?raw=true)
- 
+
  2. Choose the install options in this guide we will enable large file support I also enable the associations for *.git and *.sh
- 
+
 ![git_step2](./screenshots/git02.png?raw=true)
 
  3. Add Git to the windows PATH so that it's usable from both bash and Powershell.
- 
+
 ![git_step3](./screenshots/git03.png?raw=true)
 
  4. Choose where to authenticate SSL certs when connecting to a Git repository.  If your company has an internal Stash, GitLab, or GitHub instance you might want to use your company's MS CA setup.  For this guide we are connected to public GitHub instances so the bundled certs and public authentication in OpenSSL work just fine.  If you're not sure choose the OpenSSL method, you can always change it later.
@@ -97,9 +97,9 @@ The git install includes the Git application but also installs a bash shell buil
 ### Installing Vagrant
 
 Vagrant is the final tool that will orchestrate all the VM creation and networking.  This install will require a reboot for both Server and Desktop versions of Windows.
- 
 
- 1. Install Vagrant from the msi installer.  
+
+ 1. Install Vagrant from the msi installer.
 
 ![git_step1](./screenshots/vagrant01.png?raw=true)
 
@@ -152,10 +152,10 @@ Since this is the first time you bring up the VM the download may take a few min
 ![git_step6](./screenshots/ps06.png?raw=true)
 
  7a. Install the Cumulus Vx image with `vagrant box add CumulusCommunity/cumulus-vx --insecure --box-version=3.3.2 --provider virtualbox`
- 
+
  7b. Now bring up the oob-mgmt-switch with `vagrant up oob-mgmt-switch`
 
-This step is very similar to step 5a in that Vagrant detects that the Cumulus VX image is not installed locally so it fetches the VM and installs it. 
+This step is very similar to step 5a in that Vagrant detects that the Cumulus VX image is not installed locally so it fetches the VM and installs it.
 
  8. Finally once the oob-mgmt-switch has completed let's bring up some more nodes in the network: `vagrant up server01 leaf01 leaf02 spine01 spine02`
 
@@ -177,7 +177,7 @@ Now that we've deployed the VMs we can get to the actual networking fun.  For th
 ![git_step2](./screenshots/vbox_gui02.png?raw=true)
 
  3. You'll be connected to the console and it will ask about mouse capture.  The release key sequence is right control.  You will then be dropped onto the console of the oob-mgmt-server
-  
+
 ![git_step3](./screenshots/vbox_gui03.png?raw=true)
 
  4. The default login for the oob-mgmt-server is username: cumulus password: CumulusLinux!
@@ -193,7 +193,7 @@ Now that we've deployed the VMs we can get to the actual networking fun.  For th
  1. Vagrant spins up each VM with a port forward for SSH for each VM you bring up.  To find the port number that has been created use `vagrant port oob-mgmt-server`
 
 ![git_step1](./screenshots/putty01.png?raw=true)
- 
+
  2. Launch putty and connect to the oob-mgmt-server 127.0.0.1:2222
 
 ![git_step2](./screenshots/putty02.png?raw=true)


### PR DESCRIPTION
Require vagrant 2.0.2 due to the change in hashicorp box image urls. tested on libvirt on linux and vbox on mac. 